### PR TITLE
[Core] migrate tests to ethers6

### DIFF
--- a/src/core/package-lock.json
+++ b/src/core/package-lock.json
@@ -11,15 +11,9795 @@
       "dependencies": {
         "@openzeppelin/contracts": "4.9.2"
       },
+      "devDependencies": {
+        "@nomicfoundation/hardhat-toolbox": "^3.0.0",
+        "@typechain/ethers-v6": "^0.4.0"
+      },
       "engines": {
         "node": ">=14.0.0",
         "npm": ">=8.0.0"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz",
+      "integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@chainsafe/as-sha256": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz",
+      "integrity": "sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@chainsafe/persistent-merkle-tree": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.4.2.tgz",
+      "integrity": "sha512-lLO3ihKPngXLTus/L7WHKaw9PnNJWizlOF1H9NNzHP6Xvh82vzg9F2bzkXhYIFshMZ2gTCEz8tq6STe7r5NDfQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@chainsafe/as-sha256": "^0.3.1"
+      }
+    },
+    "node_modules/@chainsafe/ssz": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.9.4.tgz",
+      "integrity": "sha512-77Qtg2N1ayqs4Bg/wvnWfg5Bta7iy7IRh8XqXh7oNMeP2HBbBwx8m6yTpA8p0EHItWPEBkgZd5S5/LSlp3GXuQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@chainsafe/as-sha256": "^0.3.1",
+        "@chainsafe/persistent-merkle-tree": "^0.4.2",
+        "case": "^1.6.3"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@ethersproject/abi": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+      "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-provider": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+      "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-signer": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/address": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/base64": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+      "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/basex": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
+      "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/bignumber": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "bn.js": "^5.2.1"
+      }
+    },
+    "node_modules/@ethersproject/bytes": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/constants": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+      "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/contracts": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/hash": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/hdnode": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+      "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/json-wallets": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+      "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "aes-js": "3.0.0",
+        "scrypt-js": "3.0.1"
+      }
+    },
+    "node_modules/@ethersproject/json-wallets/node_modules/aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@ethersproject/keccak256": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "js-sha3": "0.8.0"
+      }
+    },
+    "node_modules/@ethersproject/logger": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/@ethersproject/networks": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
+      "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/pbkdf2": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+      "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/properties": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+      "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/providers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
+      "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0",
+        "bech32": "1.1.4",
+        "ws": "7.4.6"
+      }
+    },
+    "node_modules/@ethersproject/providers/node_modules/ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ethersproject/random": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
+      "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/rlp": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/sha2": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
+      "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@ethersproject/signing-key": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "bn.js": "^5.2.1",
+        "elliptic": "6.5.4",
+        "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@ethersproject/solidity": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
+      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/strings": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+      "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/transactions": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/units": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
+      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/wallet": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+      "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/json-wallets": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/web": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
+      "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/wordlists": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+      "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@metamask/eth-sig-util": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz",
+      "integrity": "sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ethereumjs-abi": "^0.6.8",
+        "ethereumjs-util": "^6.2.1",
+        "ethjs-util": "^0.1.6",
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@metamask/eth-sig-util/node_modules/@types/bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@metamask/eth-sig-util/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@metamask/eth-sig-util/node_modules/ethereumjs-util": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/bn.js": "^4.11.3",
+        "bn.js": "^4.11.0",
+        "create-hash": "^1.1.2",
+        "elliptic": "^6.5.2",
+        "ethereum-cryptography": "^0.1.3",
+        "ethjs-util": "0.1.6",
+        "rlp": "^2.2.3"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-block": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-5.0.1.tgz",
+      "integrity": "sha512-u1Yioemi6Ckj3xspygu/SfFvm8vZEO8/Yx5a1QLzi6nVU0jz3Pg2OmHKJ5w+D9Ogk1vhwRiqEBAqcb0GVhCyHw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-common": "4.0.1",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
+        "@nomicfoundation/ethereumjs-trie": "6.0.1",
+        "@nomicfoundation/ethereumjs-tx": "5.0.1",
+        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "ethereum-cryptography": "0.1.3",
+        "ethers": "^5.7.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-block/node_modules/ethers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-blockchain": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-7.0.1.tgz",
+      "integrity": "sha512-NhzndlGg829XXbqJEYrF1VeZhAwSPgsK/OB7TVrdzft3y918hW5KNd7gIZ85sn6peDZOdjBsAXIpXZ38oBYE5A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-block": "5.0.1",
+        "@nomicfoundation/ethereumjs-common": "4.0.1",
+        "@nomicfoundation/ethereumjs-ethash": "3.0.1",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
+        "@nomicfoundation/ethereumjs-trie": "6.0.1",
+        "@nomicfoundation/ethereumjs-tx": "5.0.1",
+        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "abstract-level": "^1.0.3",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "level": "^8.0.0",
+        "lru-cache": "^5.1.1",
+        "memory-level": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-common": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-4.0.1.tgz",
+      "integrity": "sha512-OBErlkfp54GpeiE06brBW/TTbtbuBJV5YI5Nz/aB2evTDo+KawyEzPjBlSr84z/8MFfj8wS2wxzQX1o32cev5g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "crc-32": "^1.2.0"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-ethash": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-3.0.1.tgz",
+      "integrity": "sha512-KDjGIB5igzWOp8Ik5I6QiRH5DH+XgILlplsHR7TEuWANZA759G6krQ6o8bvj+tRUz08YygMQu/sGd9mJ1DYT8w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-block": "5.0.1",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
+        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "abstract-level": "^1.0.3",
+        "bigint-crypto-utils": "^3.0.23",
+        "ethereum-cryptography": "0.1.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-evm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-2.0.1.tgz",
+      "integrity": "sha512-oL8vJcnk0Bx/onl+TgQOQ1t/534GKFaEG17fZmwtPFeH8S5soiBYPCLUrvANOl4sCp9elYxIMzIiTtMtNNN8EQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/providers": "^5.7.1",
+        "@nomicfoundation/ethereumjs-common": "4.0.1",
+        "@nomicfoundation/ethereumjs-tx": "5.0.1",
+        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "mcl-wasm": "^0.7.1",
+        "rustbn.js": "~0.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-rlp": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.1.tgz",
+      "integrity": "sha512-xtxrMGa8kP4zF5ApBQBtjlSbN5E2HI8m8FYgVSYAnO6ssUoY5pVPGy2H8+xdf/bmMa22Ce8nWMH3aEW8CcqMeQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "rlp": "bin/rlp"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-statemanager": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-2.0.1.tgz",
+      "integrity": "sha512-B5ApMOnlruVOR7gisBaYwFX+L/AP7i/2oAahatssjPIBVDF6wTX1K7Qpa39E/nzsH8iYuL3krkYeUFIdO3EMUQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-common": "4.0.1",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "ethers": "^5.7.1",
+        "js-sdsl": "^4.1.4"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-statemanager/node_modules/ethers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-trie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-6.0.1.tgz",
+      "integrity": "sha512-A64It/IMpDVODzCgxDgAAla8jNjNtsoQZIzZUfIV5AY6Coi4nvn7+VReBn5itlxMiL2yaTlQr9TRWp3CSI6VoA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
+        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "ethereum-cryptography": "0.1.3",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-tx": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-5.0.1.tgz",
+      "integrity": "sha512-0HwxUF2u2hrsIM1fsasjXvlbDOq1ZHFV2dd1yGq8CA+MEYhaxZr8OTScpVkkxqMwBcc5y83FyPl0J9MZn3kY0w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@chainsafe/ssz": "^0.9.2",
+        "@ethersproject/providers": "^5.7.2",
+        "@nomicfoundation/ethereumjs-common": "4.0.1",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
+        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "ethereum-cryptography": "0.1.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-util": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-9.0.1.tgz",
+      "integrity": "sha512-TwbhOWQ8QoSCFhV/DDfSmyfFIHjPjFBj957219+V3jTZYZ2rf9PmDtNOeZWAE3p3vlp8xb02XGpd0v6nTUPbsA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@chainsafe/ssz": "^0.10.0",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
+        "ethereum-cryptography": "0.1.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-util/node_modules/@chainsafe/persistent-merkle-tree": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.5.0.tgz",
+      "integrity": "sha512-l0V1b5clxA3iwQLXP40zYjyZYospQLZXzBVIhhr9kDg/1qHZfzzHw0jj4VPBijfYCArZDlPkRi1wZaV2POKeuw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@chainsafe/as-sha256": "^0.3.1"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-util/node_modules/@chainsafe/ssz": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.10.2.tgz",
+      "integrity": "sha512-/NL3Lh8K+0q7A3LsiFq09YXS9fPE+ead2rr7vM2QK8PLzrNsw3uqrif9bpRX5UxgeRjM+vYi+boCM3+GM4ovXg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@chainsafe/as-sha256": "^0.3.1",
+        "@chainsafe/persistent-merkle-tree": "^0.5.0"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-vm": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-7.0.1.tgz",
+      "integrity": "sha512-rArhyn0jPsS/D+ApFsz3yVJMQ29+pVzNZ0VJgkzAZ+7FqXSRtThl1C1prhmlVr3YNUlfpZ69Ak+RUT4g7VoOuQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-block": "5.0.1",
+        "@nomicfoundation/ethereumjs-blockchain": "7.0.1",
+        "@nomicfoundation/ethereumjs-common": "4.0.1",
+        "@nomicfoundation/ethereumjs-evm": "2.0.1",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
+        "@nomicfoundation/ethereumjs-statemanager": "2.0.1",
+        "@nomicfoundation/ethereumjs-trie": "6.0.1",
+        "@nomicfoundation/ethereumjs-tx": "5.0.1",
+        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "mcl-wasm": "^0.7.1",
+        "rustbn.js": "~0.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-chai-matchers": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.0.1.tgz",
+      "integrity": "sha512-qWKndseO8IPt8HiVamgEAutcBOYtX7/O6NPfe7uMNWxY2ywWaiWjDcRFuYYqxrZOMyQZl6ZuiHxbaRNctTUgLw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/chai-as-promised": "^7.1.3",
+        "chai-as-promised": "^7.1.1",
+        "deep-eql": "^4.0.1",
+        "ordinal": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-ethers": "^3.0.0",
+        "chai": "^4.2.0",
+        "ethers": "^6.1.0",
+        "hardhat": "^2.9.4"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ethers": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.0.3.tgz",
+      "integrity": "sha512-asTxUs6vg586UqL9Bi5sMvB7IrYebbgm3FkpxacbGsnb8Vr+8BB2k07nB0HNEPG3GLhTTFzalsbl0raGiPTUYg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "lodash.isequal": "^4.5.0"
+      },
+      "peerDependencies": {
+        "ethers": "^6.1.0",
+        "hardhat": "^2.0.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-network-helpers": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.0.8.tgz",
+      "integrity": "sha512-MNqQbzUJZnCMIYvlniC3U+kcavz/PhhQSsY90tbEtUyMj/IQqsLwIRZa4ctjABh3Bz0KCh9OXUZ7Yk/d9hr45Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ethereumjs-util": "^7.1.4"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.9.5"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-toolbox": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-3.0.0.tgz",
+      "integrity": "sha512-MsteDXd0UagMksqm9KvcFG6gNKYNa3GGNCy73iQ6bEasEgg2v8Qjl6XA5hjs8o5UD5A3153B6W2BIVJ8SxYUtA==",
+      "dev": true,
+      "peerDependencies": {
+        "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
+        "@nomicfoundation/hardhat-ethers": "^3.0.0",
+        "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
+        "@nomicfoundation/hardhat-verify": "^1.0.0",
+        "@typechain/ethers-v6": "^0.4.0",
+        "@typechain/hardhat": "^8.0.0",
+        "@types/chai": "^4.2.0",
+        "@types/mocha": ">=9.1.0",
+        "@types/node": ">=12.0.0",
+        "chai": "^4.2.0",
+        "ethers": "^6.4.0",
+        "hardhat": "^2.11.0",
+        "hardhat-gas-reporter": "^1.0.8",
+        "solidity-coverage": "^0.8.1",
+        "ts-node": ">=8.0.0",
+        "typechain": "^8.2.0",
+        "typescript": ">=4.5.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-verify": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-1.0.3.tgz",
+      "integrity": "sha512-KUj4O/Hd8QB6cr/rxEmRG0zcDjRUNYhWbjtGGwE4lUNuaEhVIDt/cHGJtF/A6lANQR0mpaxC6fwojhzice/ykQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abi": "^5.1.2",
+        "@ethersproject/address": "^5.0.2",
+        "cbor": "^8.1.0",
+        "chalk": "^2.4.2",
+        "debug": "^4.1.1",
+        "lodash.clonedeep": "^4.5.0",
+        "semver": "^6.3.0",
+        "table": "^6.8.0",
+        "undici": "^5.14.0"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.0.4"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer/-/solidity-analyzer-0.1.1.tgz",
+      "integrity": "sha512-1LMtXj1puAxyFusBgUIy5pZk3073cNXYnXUpuNKFghHbIit/xZgbk0AokpUADbNm3gyD6bFWl3LRFh3dhVdREg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      },
+      "optionalDependencies": {
+        "@nomicfoundation/solidity-analyzer-darwin-arm64": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-darwin-x64": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-freebsd-x64": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-arm64-gnu": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-arm64-musl": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-x64-gnu": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-x64-musl": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-win32-arm64-msvc": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-win32-ia32-msvc": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-win32-x64-msvc": "0.1.1"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-darwin-arm64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.1.1.tgz",
+      "integrity": "sha512-KcTodaQw8ivDZyF+D76FokN/HdpgGpfjc/gFCImdLUyqB6eSWVaZPazMbeAjmfhx3R0zm/NYVzxwAokFKgrc0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-darwin-x64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-x64/-/solidity-analyzer-darwin-x64-0.1.1.tgz",
+      "integrity": "sha512-XhQG4BaJE6cIbjAVtzGOGbK3sn1BO9W29uhk9J8y8fZF1DYz0Doj8QDMfpMu+A6TjPDs61lbsmeYodIDnfveSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-freebsd-x64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-freebsd-x64/-/solidity-analyzer-freebsd-x64-0.1.1.tgz",
+      "integrity": "sha512-GHF1VKRdHW3G8CndkwdaeLkVBi5A9u2jwtlS7SLhBc8b5U/GcoL39Q+1CSO3hYqePNP+eV5YI7Zgm0ea6kMHoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-gnu": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-gnu/-/solidity-analyzer-linux-arm64-gnu-0.1.1.tgz",
+      "integrity": "sha512-g4Cv2fO37ZsUENQ2vwPnZc2zRenHyAxHcyBjKcjaSmmkKrFr64yvzeNO8S3GBFCo90rfochLs99wFVGT/0owpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-musl": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-musl/-/solidity-analyzer-linux-arm64-musl-0.1.1.tgz",
+      "integrity": "sha512-WJ3CE5Oek25OGE3WwzK7oaopY8xMw9Lhb0mlYuJl/maZVo+WtP36XoQTb7bW/i8aAdHW5Z+BqrHMux23pvxG3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-x64-gnu": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-gnu/-/solidity-analyzer-linux-x64-gnu-0.1.1.tgz",
+      "integrity": "sha512-5WN7leSr5fkUBBjE4f3wKENUy9HQStu7HmWqbtknfXkkil+eNWiBV275IOlpXku7v3uLsXTOKpnnGHJYI2qsdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-x64-musl": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-musl/-/solidity-analyzer-linux-x64-musl-0.1.1.tgz",
+      "integrity": "sha512-KdYMkJOq0SYPQMmErv/63CwGwMm5XHenEna9X9aB8mQmhDBrYrlAOSsIPgFCUSL0hjxE3xHP65/EPXR/InD2+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-win32-arm64-msvc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-arm64-msvc/-/solidity-analyzer-win32-arm64-msvc-0.1.1.tgz",
+      "integrity": "sha512-VFZASBfl4qiBYwW5xeY20exWhmv6ww9sWu/krWSesv3q5hA0o1JuzmPHR4LPN6SUZj5vcqci0O6JOL8BPw+APg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-win32-ia32-msvc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-ia32-msvc/-/solidity-analyzer-win32-ia32-msvc-0.1.1.tgz",
+      "integrity": "sha512-JnFkYuyCSA70j6Si6cS1A9Gh1aHTEb8kOTBApp/c7NRTFGNMH8eaInKlyuuiIbvYFhlXW4LicqyYuWNNq9hkpQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-win32-x64-msvc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-x64-msvc/-/solidity-analyzer-win32-x64-msvc-0.1.1.tgz",
+      "integrity": "sha512-HrVJr6+WjIXGnw3Q9u6KQcbZCtk0caVWhCdFADySvRyUxJ8PnzlaP+MhwNE8oyT8OZ6ejHBRrrgjSqDCFXGirw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@openzeppelin/contracts": {
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.2.tgz",
       "integrity": "sha512-mO+y6JaqXjWeMh9glYVzVu8HYPGknAAnWyxTRhGeckOruyXQMNnlcW6w/Dx9ftLeIQk6N+ZJFuVmTwF7lEIFrg=="
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.5.tgz",
+      "integrity": "sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "~1.2.0",
+        "@noble/secp256k1": "~1.7.0",
+        "@scure/base": "~1.1.0"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.1.tgz",
+      "integrity": "sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "~1.2.0",
+        "@scure/base": "~1.1.0"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/@sentry/core": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
+      "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@sentry/hub": "5.30.0",
+        "@sentry/minimal": "5.30.0",
+        "@sentry/types": "5.30.0",
+        "@sentry/utils": "5.30.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@sentry/hub": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
+      "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@sentry/types": "5.30.0",
+        "@sentry/utils": "5.30.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/hub/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@sentry/minimal": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
+      "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@sentry/hub": "5.30.0",
+        "@sentry/types": "5.30.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/minimal/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@sentry/node": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.30.0.tgz",
+      "integrity": "sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@sentry/core": "5.30.0",
+        "@sentry/hub": "5.30.0",
+        "@sentry/tracing": "5.30.0",
+        "@sentry/types": "5.30.0",
+        "@sentry/utils": "5.30.0",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@sentry/tracing": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.30.0.tgz",
+      "integrity": "sha512-dUFowCr0AIMwiLD7Fs314Mdzcug+gBVo/+NCMyDw8tFxJkwWAKl7Qa2OZxLQ0ZHjakcj1hNKfCQJ9rhyfOl4Aw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@sentry/hub": "5.30.0",
+        "@sentry/minimal": "5.30.0",
+        "@sentry/types": "5.30.0",
+        "@sentry/utils": "5.30.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@sentry/types": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
+      "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.30.0.tgz",
+      "integrity": "sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@sentry/types": "5.30.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@solidity-parser/parser": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.5.tgz",
+      "integrity": "sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "antlr4ts": "^0.5.0-alpha.4"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@typechain/ethers-v6": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.4.0.tgz",
+      "integrity": "sha512-vD3Agzz63Gf2XlU3ed2/y+8dLWQj+wf+4Eq+0JXsyOio/plyV5F6r0yYe+s3XdGI858U3Sr263pl8mliDrUqbw==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "ts-essentials": "^7.0.1"
+      },
+      "peerDependencies": {
+        "ethers": "6.x",
+        "typechain": "^8.2.0",
+        "typescript": ">=4.7.0"
+      }
+    },
+    "node_modules/@typechain/hardhat": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-8.0.0.tgz",
+      "integrity": "sha512-XUVbqlMx8tJTOmzZCD/r196CidtNWAnTBZRcYxjLTKgcJMvc/kHQpWBnVMMB5QHxVKpYpCiz8g07FYCpG8rrjA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fs-extra": "^9.1.0"
+      },
+      "peerDependencies": {
+        "@typechain/ethers-v6": "^0.4.0",
+        "ethers": "^6.1.0",
+        "hardhat": "^2.9.9",
+        "typechain": "^8.2.0"
+      }
+    },
+    "node_modules/@types/bn.js": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
+      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+      "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/chai": "*"
+      }
+    },
+    "node_modules/@types/concat-stream": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.1.tgz",
+      "integrity": "sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/form-data": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+      "integrity": "sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@types/mocha": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
+      "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.1.tgz",
+      "integrity": "sha512-JIzsAvJeA/5iY6Y/OxZbv1lUcc8dNSE77lb2gnBH+/PJ3lFR1Ccvgwl5JWnHAkNHcRsT0TbpVOsiMKZ1F/yyJg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@types/pbkdf2": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+      "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/prettier": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/@types/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@types/secp256k1": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.3.tgz",
+      "integrity": "sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/abstract-level": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
+      "integrity": "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "catering": "^2.1.0",
+        "is-buffer": "^2.0.5",
+        "level-supports": "^4.0.0",
+        "level-transcoder": "^1.0.1",
+        "module-error": "^1.0.1",
+        "queue-microtask": "^1.2.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/address": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
+      "integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
+      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.0"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.4.2"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/antlr4ts": {
+      "version": "0.5.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz",
+      "integrity": "sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array.prototype.reduce": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.5.tgz",
+      "integrity": "sha512-kDdugMl7id9COE8R7MHF5jWk7Dqt/fs4Pv+JXoICnYwqpjjjbUurz6w5fT5IG6brLdJhv6/VoHB0H7oyIBXd+Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "is-string": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/base-x": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bcrypt-pbkdf/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/bigint-crypto-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.3.0.tgz",
+      "integrity": "sha512-jOTSb+drvEDxEq6OuUybOAv/xxoh3cuYRUIPyu8sSHQNKM303UQ2R1DAo45o1AkcIXw6fzbaFI1+xGGdaXs2lg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/browser-level": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
+      "integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.1",
+        "module-error": "^1.0.2",
+        "run-parallel-limit": "^1.1.0"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/case": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/case/-/case-1.6.3.tgz",
+      "integrity": "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/catering": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
+      "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cbor": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-8.1.0.tgz",
+      "integrity": "sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "nofilter": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12.19"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^4.1.2",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "check-error": "^1.0.2"
+      },
+      "peerDependencies": {
+        "chai": ">= 2.1.2 < 5"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/classic-level": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.3.0.tgz",
+      "integrity": "sha512-iwFAJQYtqRTRM0F6L8h4JCt00ZSGdOyqh7yVrhhjrOpFhmBjNlRUey64MCiyo6UmQHMJ+No3c81nujPv+n9yrg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.0",
+        "module-error": "^1.0.1",
+        "napi-macros": "^2.2.2",
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "object-assign": "^4.1.0",
+        "string-width": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "optionalDependencies": {
+        "colors": "^1.1.2"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/command-exists": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
+      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
+      "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "array-back": "^4.0.2",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.2",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/death": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/death/-/death-1.1.0.tgz",
+      "integrity": "sha512-vsV6S4KVHvTGxbEcij7hkWRv0It+sGGWVOM67dQde/o5Xjnr+KmLjxWJii2uEObIrt1CcM9w0Yaovx+iOlIL+w==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-port": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
+      "integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "address": "^1.0.1",
+        "debug": "4"
+      },
+      "bin": {
+        "detect": "bin/detect-port.js",
+        "detect-port": "bin/detect-port.js"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/difflib": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
+      "integrity": "sha512-9YVwmMb0wQHQNr5J9m6BSj6fk4pfGITGQOOs+D9Fl+INODWFOfvhIU1hNv6GgR1RBoC/9NJcwu77zShxV0kT7w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "heap": ">= 0.2.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/elliptic": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-colors": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+      "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.1",
+        "es-to-primitive": "^1.2.1",
+        "function.prototype.name": "^1.1.5",
+        "get-intrinsic": "^1.2.0",
+        "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
+        "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.5",
+        "is-array-buffer": "^3.0.2",
+        "is-callable": "^1.2.7",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.3",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
+        "string.prototype.trim": "^1.2.7",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-abstract/node_modules/object.assign": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha512-yhi5S+mNTOuRvyW4gWlg5W1byMaQGWWSYHXsuFZ7GBo7tpyOwi2EdzMP/QWxh9hwkD2m+wDVHJsxhRIj+v/b/A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.2.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha512-OarPfz0lFCiW4/AV2Oy1Rp9qu0iusTKqykwTspGCZtPxmF81JR4MmIebvF1F9+UOKth2ZubLQ4XGGaU+hSn99A==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+      "integrity": "sha512-25w1fMXQrGdoquWnScXZGckOv+Wes+JDnuN/+7ex3SauFRS72r2lFDec0EKPt2YD1wUJ/IrfEex+9yp4hfSOJA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eth-gas-reporter": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/eth-gas-reporter/-/eth-gas-reporter-0.2.25.tgz",
+      "integrity": "sha512-1fRgyE4xUB8SoqLgN3eDfpDfwEfRxh2Sz1b7wzFbyQA+9TekMmvSjjoRu9SKcSVyK+vLkLIsVbJDsTWjw195OQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abi": "^5.0.0-beta.146",
+        "@solidity-parser/parser": "^0.14.0",
+        "cli-table3": "^0.5.0",
+        "colors": "1.4.0",
+        "ethereum-cryptography": "^1.0.3",
+        "ethers": "^4.0.40",
+        "fs-readdir-recursive": "^1.1.0",
+        "lodash": "^4.17.14",
+        "markdown-table": "^1.1.3",
+        "mocha": "^7.1.1",
+        "req-cwd": "^2.0.0",
+        "request": "^2.88.0",
+        "request-promise-native": "^1.0.5",
+        "sha1": "^1.1.1",
+        "sync-request": "^6.0.0"
+      },
+      "peerDependencies": {
+        "@codechecks/client": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@codechecks/client": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/eth-gas-reporter/node_modules/aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/eth-gas-reporter/node_modules/ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/eth-gas-reporter/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/chokidar": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.2.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.1.1"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/eth-gas-reporter/node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/ethereum-cryptography": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
+      "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "1.2.0",
+        "@noble/secp256k1": "1.7.1",
+        "@scure/bip32": "1.1.5",
+        "@scure/bip39": "1.1.1"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/ethers": {
+      "version": "4.0.49",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.49.tgz",
+      "integrity": "sha512-kPltTvWiyu+OktYy1IStSO16i2e7cS9D9OxZ81q2UUaiNPVrm/RTcbxamCXF9VUSKzJIdJV68EAIhTEVBalRWg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "aes-js": "3.0.0",
+        "bn.js": "^4.11.9",
+        "elliptic": "6.5.4",
+        "hash.js": "1.1.3",
+        "js-sha3": "0.5.7",
+        "scrypt-js": "2.0.4",
+        "setimmediate": "1.0.4",
+        "uuid": "2.0.1",
+        "xmlhttprequest": "1.8.0"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/flat": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
+      "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "is-buffer": "~2.0.3"
+      },
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/hash.js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/js-sha3": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+      "integrity": "sha512-GII20kjaPX0zJ8wzkTbNDYMY7msuZcTWk8S5UOh6806Jq/wz1J8/bnr8uGU0DAUmYDjj2Mr4X1cW8v/GLYnR+g==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/eth-gas-reporter/node_modules/js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "chalk": "^2.4.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/mocha": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+      "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.3.0",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "3.0.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.5",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.6",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "1.6.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/eth-gas-reporter/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/readdirp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/scrypt-js": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+      "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/eth-gas-reporter/node_modules/setimmediate": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+      "integrity": "sha512-/TjEmXQVEzdod/FFskf3o7oOAsGhHf2j1dZqRFbDzq4F3mvvxflIIi4Hd3bLQE9y/CpwqfSQam5JakI/mi3Pog==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/eth-gas-reporter/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/supports-color": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+      "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-nWg9+Oa3qD2CQzHIP4qKUqwNfzKn8P0LtFhotaCTFchsV7ZfDhAybeip/HZVeMIpZi9JgY1E3nUlwaCmZT1sEg==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/eth-gas-reporter/node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/eth-gas-reporter/node_modules/yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/eth-gas-reporter/node_modules/yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ethereum-bloom-filters": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz",
+      "integrity": "sha512-rxJ5OFN3RwjQxDcFP2Z5+Q9ho4eIdEmSc2ht0fCu8Se9nbXjZ7/031uXoUYJ87KHCOdVeiUuwSnoS7hmYAGVHA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "js-sha3": "^0.8.0"
+      }
+    },
+    "node_modules/ethereum-cryptography": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/pbkdf2": "^3.0.0",
+        "@types/secp256k1": "^4.0.1",
+        "blakejs": "^1.1.0",
+        "browserify-aes": "^1.2.0",
+        "bs58check": "^2.1.2",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "hash.js": "^1.1.7",
+        "keccak": "^3.0.0",
+        "pbkdf2": "^3.0.17",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.1.2",
+        "scrypt-js": "^3.0.0",
+        "secp256k1": "^4.0.1",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/ethereumjs-abi": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
+      "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bn.js": "^4.11.8",
+        "ethereumjs-util": "^6.0.0"
+      }
+    },
+    "node_modules/ethereumjs-abi/node_modules/@types/bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/ethereumjs-abi/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/ethereumjs-abi/node_modules/ethereumjs-util": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/bn.js": "^4.11.3",
+        "bn.js": "^4.11.0",
+        "create-hash": "^1.1.2",
+        "elliptic": "^6.5.2",
+        "ethereum-cryptography": "^0.1.3",
+        "ethjs-util": "0.1.6",
+        "rlp": "^2.2.3"
+      }
+    },
+    "node_modules/ethereumjs-util": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
+      "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/bn.js": "^5.1.0",
+        "bn.js": "^5.1.2",
+        "create-hash": "^1.1.2",
+        "ethereum-cryptography": "^0.1.3",
+        "rlp": "^2.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.6.3.tgz",
+      "integrity": "sha512-g8wLXeRWSGDD0T+wsL3pvyc3aYnmxEEAwH8LSoDTDRhRsmJeNs9YMXlNU7ax2caO+zHkeI9MkHiz6rwxEjN4Mw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.9.2",
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.7.1",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/ethjs-unit": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
+      "integrity": "sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bn.js": "4.11.6",
+        "number-to-bn": "1.7.0"
+      },
+      "engines": {
+        "node": ">=6.5.0",
+        "npm": ">=3"
+      }
+    },
+    "node_modules/ethjs-unit/node_modules/bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/ethjs-util": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "is-hex-prefixed": "1.0.0",
+        "strip-hex-prefix": "1.0.0"
+      },
+      "engines": {
+        "node": ">=6.5.0",
+        "npm": ">=3"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "peer": true
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
+      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/fastq": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/fp-ts": {
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.19.3.tgz",
+      "integrity": "sha512-H5KQDspykdHuztLTg+ajGN0Z2qUjcEf3Ybxc6hLt0k7/zPkn29XnKnxlBPyW2XIddWrGaJBzBl4VLYOtk39yZg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-port": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+      "integrity": "sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/ghost-testrpc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/ghost-testrpc/-/ghost-testrpc-0.0.2.tgz",
+      "integrity": "sha512-i08dAEgJ2g8z5buJIrCTduwPIhih3DP+hOCTyyryikfV8T0bNvHnGXO67i0DD1H4GBDETTclPy9njZbfluQYrQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "chalk": "^2.4.2",
+        "node-emoji": "^1.10.0"
+      },
+      "bin": {
+        "testrpc-sc": "index.js"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "global-prefix": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+      "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.0.3",
+        "glob": "^7.1.3",
+        "ignore": "^5.1.1",
+        "merge2": "^1.2.3",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/hardhat": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.16.1.tgz",
+      "integrity": "sha512-QpBjGXFhhSYoYBGEHyoau/A63crZOP+i3GbNxzLGkL6IklzT+piN14+wGnINNCg5BLSKisQI/RAySPzaWRcx/g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abi": "^5.1.2",
+        "@metamask/eth-sig-util": "^4.0.0",
+        "@nomicfoundation/ethereumjs-block": "5.0.1",
+        "@nomicfoundation/ethereumjs-blockchain": "7.0.1",
+        "@nomicfoundation/ethereumjs-common": "4.0.1",
+        "@nomicfoundation/ethereumjs-evm": "2.0.1",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.1",
+        "@nomicfoundation/ethereumjs-statemanager": "2.0.1",
+        "@nomicfoundation/ethereumjs-trie": "6.0.1",
+        "@nomicfoundation/ethereumjs-tx": "5.0.1",
+        "@nomicfoundation/ethereumjs-util": "9.0.1",
+        "@nomicfoundation/ethereumjs-vm": "7.0.1",
+        "@nomicfoundation/solidity-analyzer": "^0.1.0",
+        "@sentry/node": "^5.18.1",
+        "@types/bn.js": "^5.1.0",
+        "@types/lru-cache": "^5.1.0",
+        "abort-controller": "^3.0.0",
+        "adm-zip": "^0.4.16",
+        "aggregate-error": "^3.0.0",
+        "ansi-escapes": "^4.3.0",
+        "chalk": "^2.4.2",
+        "chokidar": "^3.4.0",
+        "ci-info": "^2.0.0",
+        "debug": "^4.1.1",
+        "enquirer": "^2.3.0",
+        "env-paths": "^2.2.0",
+        "ethereum-cryptography": "^1.0.3",
+        "ethereumjs-abi": "^0.6.8",
+        "find-up": "^2.1.0",
+        "fp-ts": "1.19.3",
+        "fs-extra": "^7.0.1",
+        "glob": "7.2.0",
+        "immutable": "^4.0.0-rc.12",
+        "io-ts": "1.10.4",
+        "keccak": "^3.0.2",
+        "lodash": "^4.17.11",
+        "mnemonist": "^0.38.0",
+        "mocha": "^10.0.0",
+        "p-map": "^4.0.0",
+        "raw-body": "^2.4.1",
+        "resolve": "1.17.0",
+        "semver": "^6.3.0",
+        "solc": "0.7.3",
+        "source-map-support": "^0.5.13",
+        "stacktrace-parser": "^0.1.10",
+        "tsort": "0.0.1",
+        "undici": "^5.14.0",
+        "uuid": "^8.3.2",
+        "ws": "^7.4.6"
+      },
+      "bin": {
+        "hardhat": "internal/cli/bootstrap.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "ts-node": "*",
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/hardhat-gas-reporter": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/hardhat-gas-reporter/-/hardhat-gas-reporter-1.0.9.tgz",
+      "integrity": "sha512-INN26G3EW43adGKBNzYWOlI3+rlLnasXTwW79YNnUhXPDa+yHESgt639dJEs37gCjhkbNKcRRJnomXEuMFBXJg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "array-uniq": "1.0.3",
+        "eth-gas-reporter": "^0.2.25",
+        "sha1": "^1.1.1"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.0.2"
+      }
+    },
+    "node_modules/hardhat/node_modules/@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/hardhat/node_modules/ethereum-cryptography": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
+      "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "1.2.0",
+        "@noble/secp256k1": "1.7.1",
+        "@scure/bip32": "1.1.5",
+        "@scure/bip39": "1.1.1"
+      }
+    },
+    "node_modules/hardhat/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/hardhat/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "peer": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/hardhat/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/hardhat/node_modules/ws": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hash-base": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/heap": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
+      "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/http-basic": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-8.1.3.tgz",
+      "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^1.6.2",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/http-response-object/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/ignore": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/immutable": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.1.tgz",
+      "integrity": "sha512-lj9cnmB/kVS0QHsJnYKD1uo3o39nrbKxszjnqS9Fr6NB7bZzW45U6WSGBPKXDL/CvDKqDNPA4r3DoDQ8GTxo2A==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/internal-slot": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/io-ts": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.10.4.tgz",
+      "integrity": "sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fp-ts": "^1.0.0"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hex-prefixed": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+      "integrity": "sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6.5.0",
+        "npm": ">=3"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.1.tgz",
+      "integrity": "sha512-6Gsx8R0RucyePbWqPssR8DyfuXmLBooYN5cZFZKjHGnQuaf7pEzhtpceagJxVu4LqhYY5EYA7nko3FmeHZ1KbA==",
+      "dev": true,
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonschema": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
+      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/keccak": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.3.tgz",
+      "integrity": "sha512-JZrLIAJWuZxKbCilMpNz5Vj7Vtb4scDG3dMXLOsbzBmQGyjwE61BbW7bJkfKKCShXiQZt3T6sBgALRtmd+nZaQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==",
+      "dev": true,
+      "peer": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/level": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/level/-/level-8.0.0.tgz",
+      "integrity": "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "browser-level": "^1.0.1",
+        "classic-level": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/level"
+      }
+    },
+    "node_modules/level-supports": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
+      "integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/level-transcoder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
+      "integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "module-error": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/log-symbols/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-symbols/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "get-func-name": "^2.0.0"
+      }
+    },
+    "node_modules/lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/markdown-table": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
+      "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/mcl-wasm": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/mcl-wasm/-/mcl-wasm-0.7.9.tgz",
+      "integrity": "sha512-iJIUcQWA88IJB/5L15GnJVnSQJmf/YaxxV6zRavv83HILHaJQb6y0iFyDMdDO0gN8X37tdxmAOrH/P8B6RB8sQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/memory-level": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/memory-level/-/memory-level-1.0.0.tgz",
+      "integrity": "sha512-UXzwewuWeHBz5krr7EvehKcmLFNoXxGcvuYhC41tRnkrTbJohtS7kVn9akmgirtRygg+f7Yjsfi8Uu5SGSQ4Og==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "abstract-level": "^1.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "module-error": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mnemonist": {
+      "version": "0.38.5",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.5.tgz",
+      "integrity": "sha512-bZTFT5rrPKtPJxj8KSV0WkPyNxl72vQepqqVUAW2ARUpUSF2qXMB6jZj7hW5/k7C1rtpzqbD/IIbJwLXUjCHeg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "obliterator": "^2.0.0"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "5.0.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.3",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "workerpool": "6.2.1",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/mocha/node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mocha/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/mocha/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/module-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
+      "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-macros": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
+      "integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/node-emoji": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
+      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/node-environment-flags": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      }
+    },
+    "node_modules/node-environment-flags/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/nofilter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
+      "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12.19"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/number-to-bn": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+      "integrity": "sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bn.js": "4.11.6",
+        "strip-hex-prefix": "1.0.0"
+      },
+      "engines": {
+        "node": ">=6.5.0",
+        "npm": ">=3"
+      }
+    },
+    "node_modules/number-to-bn/node_modules/bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "dev": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.getownpropertydescriptors": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.6.tgz",
+      "integrity": "sha512-lq+61g26E/BgHv0ZTFgRvi7NMEPuAxLkFU7rukXjc/AlwH4Am5xXVnIXy3un1bg/JPbXHrixRkK1itUzzPiIjQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "array.prototype.reduce": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.21.2",
+        "safe-array-concat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obliterator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
+      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ordinal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ordinal/-/ordinal-1.0.3.tgz",
+      "integrity": "sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/pbkdf2": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/promise": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "asap": "~2.0.6"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/recursive-readdir": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
+      "integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
+      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "functions-have-names": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/req-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-2.0.0.tgz",
+      "integrity": "sha512-ueoIoLo1OfB6b05COxAA9UpeoscNpYyM+BqYlA7H6LVF4hKGPXQQSSaD2YmvDVJMkk4UDpAHIeU1zG53IqjvlQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "req-from": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/req-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/req-from/-/req-from-2.0.0.tgz",
+      "integrity": "sha512-LzTfEVDVQHBRfjOUMgNBA+V6DWsSnoeKzf42J7l0xa/B4jyPOuuF5MlNSmomLNGemWTnV2TIdjSSLnEn95fOQA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "resolve-from": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "lodash": "^4.17.19"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
+      }
+    },
+    "node_modules/request-promise-native": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
+      }
+    },
+    "node_modules/request/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/rlp": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
+      "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bn.js": "^5.2.0"
+      },
+      "bin": {
+        "rlp": "bin/rlp"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/run-parallel-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
+      "integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rustbn.js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
+      "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.0.tgz",
+      "integrity": "sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "has-symbols": "^1.0.3",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-array-concat/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/sc-istanbul": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/sc-istanbul/-/sc-istanbul-0.4.6.tgz",
+      "integrity": "sha512-qJFF/8tW/zJsbyfh/iT/ZM5QNHE3CXxtLJbZsL+CzdJLBsPD7SedJZoUA4d8iAcN2IoMp/Dx80shOOd2x96X/g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "istanbul": "lib/cli.js"
+      }
+    },
+    "node_modules/sc-istanbul/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/sc-istanbul/node_modules/glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/sc-istanbul/node_modules/has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sc-istanbul/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/sc-istanbul/node_modules/js-yaml/node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/sc-istanbul/node_modules/resolve": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+      "integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/sc-istanbul/node_modules/supports-color": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+      "integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/scrypt-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/secp256k1": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
+      "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "elliptic": "^6.5.4",
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      }
+    },
+    "node_modules/sha1": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
+      "integrity": "sha512-dZBS6OrMjtgVkopB1Gmo4RQCDKiZsqcpAQpkV/aaj+FCrCg8r4I4qMkDPQjBgLIxlmu9k4nUbWq6ohXahOneYA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "charenc": ">= 0.0.1",
+        "crypt": ">= 0.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/solc": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.7.3.tgz",
+      "integrity": "sha512-GAsWNAjGzIDg7VxzP6mPjdurby3IkGCjQcM8GFYZT6RyaoUZKmMU6Y7YwG+tFGhv7dwZ8rmR4iwFDrrD99JwqA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "command-exists": "^1.2.8",
+        "commander": "3.0.2",
+        "follow-redirects": "^1.12.1",
+        "fs-extra": "^0.30.0",
+        "js-sha3": "0.8.0",
+        "memorystream": "^0.3.1",
+        "require-from-string": "^2.0.0",
+        "semver": "^5.5.0",
+        "tmp": "0.0.33"
+      },
+      "bin": {
+        "solcjs": "solcjs"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/solc/node_modules/fs-extra": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+      "integrity": "sha512-UvSPKyhMn6LEd/WpUaV9C9t3zATuqoqfWc3QdPhPLb58prN9tqYPlPWi8Krxi44loBoUzlobqZ3+8tGpxxSzwA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
+      }
+    },
+    "node_modules/solc/node_modules/jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
+      "dev": true,
+      "peer": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/solc/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/solidity-coverage": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.8.4.tgz",
+      "integrity": "sha512-xeHOfBOjdMF6hWTbt42iH4x+7j1Atmrf5OldDPMxI+i/COdExUxszOswD9qqvcBTaLGiOrrpnh9UZjSpt4rBsg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abi": "^5.0.9",
+        "@solidity-parser/parser": "^0.16.0",
+        "chalk": "^2.4.2",
+        "death": "^1.1.0",
+        "detect-port": "^1.3.0",
+        "difflib": "^0.2.4",
+        "fs-extra": "^8.1.0",
+        "ghost-testrpc": "^0.0.2",
+        "global-modules": "^2.0.0",
+        "globby": "^10.0.1",
+        "jsonschema": "^1.2.4",
+        "lodash": "^4.17.15",
+        "mocha": "7.1.2",
+        "node-emoji": "^1.10.0",
+        "pify": "^4.0.1",
+        "recursive-readdir": "^2.2.2",
+        "sc-istanbul": "^0.4.5",
+        "semver": "^7.3.4",
+        "shelljs": "^0.8.3",
+        "web3-utils": "^1.3.6"
+      },
+      "bin": {
+        "solidity-coverage": "plugins/bin.js"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.11.0"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/@solidity-parser/parser": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.16.1.tgz",
+      "integrity": "sha512-PdhRFNhbTtu3x8Axm0uYpqOy/lODYQK+MlYSgqIsq2L8SFYEHJPHNUiOTAJbDGzNjjr1/n9AcIayxafR/fWmYw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "antlr4ts": "^0.5.0-alpha.4"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/chokidar": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.2.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.1.1"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/solidity-coverage/node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/flat": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
+      "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "is-buffer": "~2.0.3"
+      },
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "peer": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "chalk": "^2.4.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/mocha": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.2.tgz",
+      "integrity": "sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.3.0",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "3.0.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.5",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.6",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "1.6.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/solidity-coverage/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/readdirp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/supports-color": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+      "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/solidity-coverage/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/solidity-coverage/node_modules/yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/solidity-coverage/node_modules/yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+      "integrity": "sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "amdefine": ">=0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sshpk/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/stacktrace-parser": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz",
+      "integrity": "sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "type-fest": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/stacktrace-parser/node_modules/type-fest": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+      "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
+      "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
+      "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-hex-prefix": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+      "integrity": "sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "is-hex-prefixed": "1.0.0"
+      },
+      "engines": {
+        "node": ">=6.5.0",
+        "npm": ">=3"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/sync-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
+      "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "http-response-object": "^3.0.1",
+        "sync-rpc": "^1.2.1",
+        "then-request": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/sync-rpc": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.6.tgz",
+      "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "get-port": "^3.1.0"
+      }
+    },
+    "node_modules/table": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
+      "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table-layout/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/then-request": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
+      "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/concat-stream": "^1.6.0",
+        "@types/form-data": "0.0.33",
+        "@types/node": "^8.0.0",
+        "@types/qs": "^6.2.31",
+        "caseless": "~0.12.0",
+        "concat-stream": "^1.6.0",
+        "form-data": "^2.2.0",
+        "http-basic": "^8.1.1",
+        "http-response-object": "^3.0.1",
+        "promise": "^8.0.0",
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/then-request/node_modules/@types/node": {
+      "version": "8.10.66",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+      "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/ts-command-line-args": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/ts-command-line-args/-/ts-command-line-args-2.5.1.tgz",
+      "integrity": "sha512-H69ZwTw3rFHb5WYpQya40YAX2/w7Ut75uUECbgBIsLmM+BNuYnxsltfyyLMxy6sEeKxgijLTnQtLd0nKd6+IYw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "command-line-args": "^5.1.1",
+        "command-line-usage": "^6.1.0",
+        "string-format": "^2.0.0"
+      },
+      "bin": {
+        "write-markdown": "dist/write-markdown.js"
+      }
+    },
+    "node_modules/ts-command-line-args/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ts-command-line-args/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ts-command-line-args/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ts-command-line-args/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/ts-command-line-args/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ts-command-line-args/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ts-essentials": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
+      "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
+      "dev": true,
+      "peerDependencies": {
+        "typescript": ">=3.7.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/tsort": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tsort/-/tsort-0.0.1.tgz",
+      "integrity": "sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/tweetnacl-util": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typechain": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/typechain/-/typechain-8.2.0.tgz",
+      "integrity": "sha512-tZqhqjxJ9xAS/Lh32jccTjMkpx7sTdUVVHAy5Bf0TIer5QFNYXotiX74oCvoVYjyxUKDK3MXHtMFzMyD3kE+jg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/prettier": "^2.1.1",
+        "debug": "^4.3.1",
+        "fs-extra": "^7.0.0",
+        "glob": "7.1.7",
+        "js-sha3": "^0.8.0",
+        "lodash": "^4.17.15",
+        "mkdirp": "^1.0.4",
+        "prettier": "^2.3.1",
+        "ts-command-line-args": "^2.2.0",
+        "ts-essentials": "^7.0.1"
+      },
+      "bin": {
+        "typechain": "dist/cli/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.3.0"
+      }
+    },
+    "node_modules/typechain/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/typechain/node_modules/glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typechain/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "peer": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/typechain/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/typechain/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.22.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
+      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "peer": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/web3-utils": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.10.0.tgz",
+      "integrity": "sha512-kSaCM0uMcZTNUSmn5vMEhlo02RObGNRRCkdX0V9UTAU0+lrvn0HSaudyCo6CQzuXUsnuY2ERJGCGPfeWmv19Rg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethereumjs-util": "^7.1.0",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.10.tgz",
+      "integrity": "sha512-uxoA5vLUfRPdjCuJ1h5LlYdmTLbYfums398v3WLkM+i/Wltl2/XyZpQWKbN++ck5L64SR/grOHqtXCUKmlZPNA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/wordwrapjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/wordwrapjs/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/src/core/package.json
+++ b/src/core/package.json
@@ -36,5 +36,9 @@
   },
   "dependencies": {
     "@openzeppelin/contracts": "4.9.2"
+  },
+  "devDependencies": {
+    "@nomicfoundation/hardhat-toolbox": "^3.0.0",
+    "@typechain/ethers-v6": "^0.4.0"
   }
 }

--- a/src/core/test/AlgebraFactory.spec.ts
+++ b/src/core/test/AlgebraFactory.spec.ts
@@ -8,8 +8,6 @@ import snapshotGasCost from './shared/snapshotGasCost';
 
 import { getCreate2Address } from './shared/utilities';
 
-const { constants } = ethers;
-
 const TEST_ADDRESSES: [string, string, string] = [
   '0x1000000000000000000000000000000000000000',
   '0x2000000000000000000000000000000000000000',
@@ -33,15 +31,15 @@ describe('AlgebraFactory', () => {
     });
 
     const factoryFactory = await ethers.getContractFactory('AlgebraFactory');
-    const _factory = (await factoryFactory.deploy(poolDeployerAddress)) as AlgebraFactory;
+    const _factory = (await factoryFactory.deploy(poolDeployerAddress)) as any as AlgebraFactory;
 
     const vaultAddress = await _factory.communityVault();
 
     const poolDeployerFactory = await ethers.getContractFactory('AlgebraPoolDeployer');
-    poolDeployer = (await poolDeployerFactory.deploy(_factory, vaultAddress)) as AlgebraPoolDeployer;
+    poolDeployer = (await poolDeployerFactory.deploy(_factory, vaultAddress)) as any as AlgebraPoolDeployer;
 
     const defaultPluginFactoryFactory = await ethers.getContractFactory('MockDefaultPluginFactory');
-    defaultPluginFactory = (await defaultPluginFactoryFactory.deploy()) as MockDefaultPluginFactory;
+    defaultPluginFactory = (await defaultPluginFactoryFactory.deploy()) as any as MockDefaultPluginFactory;
 
     return _factory;
   };
@@ -137,7 +135,7 @@ describe('AlgebraFactory', () => {
     it('fails if token a is 0 or token b is 0', async () => {
       await expect(factory.createPool(TEST_ADDRESSES[0], ZeroAddress)).to.be.reverted;
       await expect(factory.createPool(ZeroAddress, TEST_ADDRESSES[0])).to.be.reverted;
-      await expect(factory.createPool(ZeroAddress, ZeroAddress)).to.be.revertedWithoutReason;
+      expect(factory.createPool(ZeroAddress, ZeroAddress)).to.be.revertedWithoutReason;
     });
 
     it('gas [ @skip-on-coverage ]', async () => {
@@ -201,7 +199,7 @@ describe('AlgebraFactory', () => {
       expect(await factory.renounceOwnershipStartTimestamp()).to.eq(0);
     });
 
-    it('stopRenounceOwnership doesnt works without start', async () => {
+    it('stopRenounceOwnership does not works without start', async () => {
       await expect(factory.stopRenounceOwnership()).to.be.reverted;
     });
 
@@ -210,7 +208,7 @@ describe('AlgebraFactory', () => {
       await expect(factory.stopRenounceOwnership()).to.emit(factory, 'RenounceOwnershipStop');
     });
 
-    it('renounceOwnership doesnt works without start', async () => {
+    it('renounceOwnership does not works without start', async () => {
       await expect(factory.renounceOwnership()).to.be.reverted;
     });
 
@@ -259,11 +257,11 @@ describe('AlgebraFactory', () => {
       await expect(factory.connect(other).setDefaultFee(200)).to.be.reverted;
     });
 
-    it('fails if new community fee greater than max fee', async () => {
+    it('fails if new default fee greater than max fee', async () => {
       await expect(factory.setDefaultFee(51000)).to.be.reverted;
     });
 
-    it('fails if new community fee eq current', async () => {
+    it('fails if new default fee eq current', async () => {
       await expect(factory.setDefaultFee(100)).to.be.reverted;
     });
 
@@ -282,12 +280,12 @@ describe('AlgebraFactory', () => {
       await expect(factory.connect(other).setDefaultTickspacing(30)).to.be.reverted;
     });
 
-    it('fails if new community fee greater than max fee & lt min fee', async () => {
+    it('fails if new default tickspacing greater than max & lt min', async () => {
       await expect(factory.setDefaultTickspacing(1100)).to.be.reverted;
       await expect(factory.setDefaultTickspacing(-1100)).to.be.reverted;
     });
 
-    it('fails if new community fee eq current', async () => {
+    it('fails if new default tickspacing eq current', async () => {
       await expect(factory.setDefaultTickspacing(60)).to.be.reverted;
     });
 

--- a/src/core/test/AlgebraPool.arbitrage.spec.ts
+++ b/src/core/test/AlgebraPool.arbitrage.spec.ts
@@ -1,5 +1,5 @@
 import Decimal from 'decimal.js';
-import { BigNumber, BigNumberish, Wallet } from 'ethers';
+import { BigNumberish, Wallet, MaxUint256 } from 'ethers';
 import { ethers } from 'hardhat';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { MockTimeAlgebraPool, TickMathTest, AlgebraPoolSwapTest } from '../typechain';
@@ -23,20 +23,12 @@ import {
   TICK_SPACINGS,
 } from './shared/utilities';
 
-const {
-  constants: { MaxUint256 },
-} = ethers;
-
 Decimal.config({ toExpNeg: -500, toExpPos: 500 });
 
-function applySqrtRatioBipsHundredthsDelta(sqrtRatio: BigNumber, bipsHundredths: number): BigNumber {
-  return BigNumber.from(
+function applySqrtRatioBipsHundredthsDelta(sqrtRatio: bigint, bipsHundredths: number): bigint {
+  return BigInt(
     new Decimal(
-      sqrtRatio
-        .mul(sqrtRatio)
-        .mul(1e6 + bipsHundredths)
-        .div(1e6)
-        .toString()
+      ((sqrtRatio * sqrtRatio * BigInt(1e6 + bipsHundredths)) / BigInt(1e6)).toString()
     )
       .sqrt()
       .floor()
@@ -61,7 +53,7 @@ describe('AlgebraPool arbitrage tests', () => {
       const maxTick = getMaxTick(tickSpacing);
 
       for (const passiveLiquidity of [
-        expandTo18Decimals(1).div(100),
+        expandTo18Decimals(1) / 100n,
         expandTo18Decimals(1),
         expandTo18Decimals(10),
         expandTo18Decimals(100),
@@ -72,8 +64,8 @@ describe('AlgebraPool arbitrage tests', () => {
 
             const pool = await fix.createPool();
 
-            await fix.token0.transfer(arbitrageur.address, BigNumber.from(2).pow(254));
-            await fix.token1.transfer(arbitrageur.address, BigNumber.from(2).pow(254));
+            await fix.token0.transfer(arbitrageur.address, 2n ** 254n);
+            await fix.token1.transfer(arbitrageur.address, 2n ** 254n);
 
             const { swapExact0For1, swapToHigherPrice, swapToLowerPrice, swapExact1For0, mint } =
                createPoolFunctions({
@@ -89,8 +81,8 @@ describe('AlgebraPool arbitrage tests', () => {
             const tickMathFactory = await ethers.getContractFactory('TickMathTest');
             const tickMath = (await tickMathFactory.deploy()) as TickMathTest;
 
-            await fix.token0.approve(tester.address, MaxUint256);
-            await fix.token1.approve(tester.address, MaxUint256);
+            await fix.token0.approve(tester, MaxUint256);
+            await fix.token1.approve(tester, MaxUint256);
 
             await pool.initialize(startingPrice);
             await pool.setFee(feeAmount);
@@ -130,24 +122,24 @@ describe('AlgebraPool arbitrage tests', () => {
 
           async function simulateSwap(
             zeroToOne: boolean,
-            amountSpecified: BigNumberish,
-            limitSqrtPrice?: BigNumber
+            amountSpecified: bigint,
+            limitSqrtPrice?: bigint
           ): Promise<{
-            executionPrice: BigNumber;
-            nextSqrtRatio: BigNumber;
-            amount0Delta: BigNumber;
-            amount1Delta: BigNumber;
+            executionPrice: bigint;
+            nextSqrtRatio: bigint;
+            amount0Delta: bigint;
+            amount1Delta: bigint;
           }> {
-            const { amount0Delta, amount1Delta, nextSqrtRatio } = await tester.callStatic.getSwapResult(
-              pool.address,
+            const { amount0Delta, amount1Delta, nextSqrtRatio } = await tester.getSwapResult.staticCall(
+              pool,
               zeroToOne,
               amountSpecified,
-              limitSqrtPrice ?? (zeroToOne ? MIN_SQRT_RATIO.add(1) : MAX_SQRT_RATIO.sub(1))
+              limitSqrtPrice ?? (zeroToOne ? MIN_SQRT_RATIO + 1n : MAX_SQRT_RATIO - 1n)
             );
 
             const executionPrice = zeroToOne
-              ? encodePriceSqrt(amount1Delta, amount0Delta.mul(-1))
-              : encodePriceSqrt(amount1Delta.mul(-1), amount0Delta);
+              ? encodePriceSqrt(amount1Delta, amount0Delta* -1n)
+              : encodePriceSqrt(amount1Delta* -1n, amount0Delta);
 
             return {
               executionPrice,
@@ -172,12 +164,8 @@ describe('AlgebraPool arbitrage tests', () => {
             },
           ]) {
             describe(description, () => {
-              function valueToken1(arbBalance0: BigNumber, arbBalance1: BigNumber) {
-                return assumedTruePriceAfterSwap
-                  .mul(assumedTruePriceAfterSwap)
-                  .mul(arbBalance0)
-                  .div(BigNumber.from(2).pow(192))
-                  .add(arbBalance1);
+              function valueToken1(arbBalance0: bigint, arbBalance1: bigint) {
+                return (assumedTruePriceAfterSwap * assumedTruePriceAfterSwap * arbBalance0) / (2n ** 192n) + arbBalance1;
               }
 
               it('not sandwiched', async () => {
@@ -199,13 +187,13 @@ describe('AlgebraPool arbitrage tests', () => {
 
                 const firstTickAboveMarginalPrice = zeroToOne
                   ? Math.ceil(
-                      (await tickMath.getTickAtSqrtRatio(
-                        applySqrtRatioBipsHundredthsDelta(executionPrice, feeAmount)
+                      Number(await tickMath.getTickAtSqrtRatio(
+                        applySqrtRatioBipsHundredthsDelta(BigInt(executionPrice), feeAmount)
                       )) / tickSpacing
                     ) * tickSpacing
                   : Math.floor(
-                      (await tickMath.getTickAtSqrtRatio(
-                        applySqrtRatioBipsHundredthsDelta(executionPrice, -feeAmount)
+                      Number(await tickMath.getTickAtSqrtRatio(
+                        applySqrtRatioBipsHundredthsDelta(BigInt(executionPrice), -feeAmount)
                       )) / tickSpacing
                     ) * tickSpacing;
                 const tickAfterFirstTickAboveMarginPrice = zeroToOne
@@ -214,17 +202,17 @@ describe('AlgebraPool arbitrage tests', () => {
 
                 const priceSwapStart = await tickMath.getSqrtRatioAtTick(firstTickAboveMarginalPrice);
 
-                let arbBalance0 = BigNumber.from(0);
-                let arbBalance1 = BigNumber.from(0);
+                let arbBalance0 = 0n;
+                let arbBalance1 = 0n;
 
                 // first frontrun to the first tick before the execution price
                 const {
                   amount0Delta: frontrunDelta0,
                   amount1Delta: frontrunDelta1,
                   executionPrice: frontrunExecutionPrice,
-                } = await simulateSwap(zeroToOne, MaxUint256.div(2), priceSwapStart);
-                arbBalance0 = arbBalance0.sub(frontrunDelta0);
-                arbBalance1 = arbBalance1.sub(frontrunDelta1);
+                } = await simulateSwap(zeroToOne, MaxUint256 / 2n, priceSwapStart);
+                arbBalance0 = arbBalance0 - frontrunDelta0;
+                arbBalance1 = arbBalance1 - frontrunDelta1;
                 zeroToOne
                   ? await swapToLowerPrice(priceSwapStart, arbitrageur.address)
                   : await swapToHigherPrice(priceSwapStart, arbitrageur.address);
@@ -236,15 +224,15 @@ describe('AlgebraPool arbitrage tests', () => {
 
                 // deposit max liquidity at the tick
                 const mintReceipt = await (
-                  await mint(wallet.address, bottomTick, topTick, BigNumber.from('40564824043007195767232224305152'))
+                  await mint(wallet.address, bottomTick, topTick, BigInt('40564824043007195767232224305152'))
                 ).wait();
                 // sub the mint costs
                 const { amount0: amount0Mint, amount1: amount1Mint } = pool.interface.decodeEventLog(
-                  pool.interface.events['Mint(address,address,int24,int24,uint128,uint256,uint256)'],
-                  mintReceipt.events?.[2].data!
+                  pool.interface.getEvent('Mint'),
+                  mintReceipt?.logs?.[2].data!
                 );
-                arbBalance0 = arbBalance0.sub(amount0Mint);
-                arbBalance1 = arbBalance1.sub(amount1Mint);
+                arbBalance0 = arbBalance0 - amount0Mint;
+                arbBalance1 = arbBalance1 - amount1Mint;
 
                 // execute the user's swap
                 const { executionPrice: executionPriceAfterFrontrun } = await simulateSwap(zeroToOne, inputAmount);
@@ -253,25 +241,25 @@ describe('AlgebraPool arbitrage tests', () => {
                   : await swapExact1For0(inputAmount, wallet.address);
 
                 // burn the arb's liquidity
-                const { amount0: amount0Burn, amount1: amount1Burn } = await pool.callStatic.burn(
+                const { amount0: amount0Burn, amount1: amount1Burn } = await pool.burn.staticCall(
                   bottomTick,
                   topTick,
-                  BigNumber.from('40564824043007195767232224305152'),
-                  []
+                  BigInt('40564824043007195767232224305152'),
+                  '0x'
                 );
-                await pool.burn(bottomTick, topTick, BigNumber.from('40564824043007195767232224305152'), []);
-                arbBalance0 = arbBalance0.add(amount0Burn);
-                arbBalance1 = arbBalance1.add(amount1Burn);
+                await pool.burn(bottomTick, topTick, BigInt('40564824043007195767232224305152'), '0x');
+                arbBalance0 = arbBalance0 + amount0Burn;
+                arbBalance1 = arbBalance1 + amount1Burn;
 
                 // add the fees as well
                 const { amount0: amount0CollectAndBurn, amount1: amount1CollectAndBurn } =
-                  await pool.callStatic.collect(arbitrageur.address, bottomTick, topTick, MaxUint128, MaxUint128);
+                  await pool.collect.staticCall(arbitrageur.address, bottomTick, topTick, MaxUint128, MaxUint128);
                 const [amount0Collect, amount1Collect] = [
-                  amount0CollectAndBurn.sub(amount0Burn),
-                  amount1CollectAndBurn.sub(amount1Burn),
+                  amount0CollectAndBurn - amount0Burn,
+                  amount1CollectAndBurn - amount1Burn,
                 ];
-                arbBalance0 = arbBalance0.add(amount0Collect);
-                arbBalance1 = arbBalance1.add(amount1Collect);
+                arbBalance0 = arbBalance0 + amount0Collect;
+                arbBalance1 = arbBalance1 + amount1Collect;
 
                 const profitToken1AfterSandwich = valueToken1(arbBalance0, arbBalance1);
 
@@ -283,10 +271,10 @@ describe('AlgebraPool arbitrage tests', () => {
                   amount0Delta: backrunDelta0,
                   amount1Delta: backrunDelta1,
                   executionPrice: backrunExecutionPrice,
-                } = await simulateSwap(!zeroToOne, MaxUint256.div(2), priceToSwapTo);
+                } = await simulateSwap(!zeroToOne, MaxUint256 / 2n, priceToSwapTo);
                 await swapToHigherPrice(priceToSwapTo, wallet.address);
-                arbBalance0 = arbBalance0.sub(backrunDelta0);
-                arbBalance1 = arbBalance1.sub(backrunDelta1);
+                arbBalance0 = arbBalance0 - backrunDelta0;
+                arbBalance1 = arbBalance1 - backrunDelta1;
 
                 expect({
                   sandwichedPrice: formatPrice(executionPriceAfterFrontrun),
@@ -324,8 +312,8 @@ describe('AlgebraPool arbitrage tests', () => {
               });
 
               it('backrun to true price after swap only', async () => {
-                let arbBalance0 = BigNumber.from(0);
-                let arbBalance1 = BigNumber.from(0);
+                let arbBalance0 = 0n;
+                let arbBalance1 = 0n;
 
                 zeroToOne
                   ? await swapExact0For1(inputAmount, wallet.address)
@@ -339,12 +327,12 @@ describe('AlgebraPool arbitrage tests', () => {
                   amount0Delta: backrunDelta0,
                   amount1Delta: backrunDelta1,
                   executionPrice: backrunExecutionPrice,
-                } = await simulateSwap(!zeroToOne, MaxUint256.div(2), priceToSwapTo);
+                } = await simulateSwap(!zeroToOne, MaxUint256 / 2n, priceToSwapTo);
                 zeroToOne
                   ? await swapToHigherPrice(priceToSwapTo, wallet.address)
                   : await swapToLowerPrice(priceToSwapTo, wallet.address);
-                arbBalance0 = arbBalance0.sub(backrunDelta0);
-                arbBalance1 = arbBalance1.sub(backrunDelta1);
+                arbBalance0 = arbBalance0 - backrunDelta0;
+                arbBalance1 = arbBalance1 - backrunDelta1;
 
                 expect({
                   arbBalanceDelta0: formatTokenAmount(arbBalance0),

--- a/src/core/test/AlgebraPool.arbitrage.spec.ts
+++ b/src/core/test/AlgebraPool.arbitrage.spec.ts
@@ -76,10 +76,10 @@ describe('AlgebraPool arbitrage tests', () => {
               });
 
             const testerFactory = await ethers.getContractFactory('AlgebraPoolSwapTest');
-            const tester = (await testerFactory.deploy()) as AlgebraPoolSwapTest;
+            const tester = (await testerFactory.deploy()) as any as AlgebraPoolSwapTest;
 
             const tickMathFactory = await ethers.getContractFactory('TickMathTest');
-            const tickMath = (await tickMathFactory.deploy()) as TickMathTest;
+            const tickMath = (await tickMathFactory.deploy()) as any as TickMathTest;
 
             await fix.token0.approve(tester, MaxUint256);
             await fix.token1.approve(tester, MaxUint256);

--- a/src/core/test/AlgebraPool.gas.spec.ts
+++ b/src/core/test/AlgebraPool.gas.spec.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'hardhat';
 import { Wallet } from 'ethers';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
-import { MockTimeAlgebraPool, TestERC20, TestAlgebraCallee, AlgebraPool } from '../typechain';
+import { MockTimeAlgebraPool, AlgebraPool } from '../typechain';
 import { expect } from './shared/expect';
 
 import { poolFixture } from './shared/fixtures';
@@ -23,10 +23,6 @@ import {
 
 describe('AlgebraPool gas tests [ @skip-on-coverage ]', () => {
   let wallet: Wallet, other: Wallet;
-
-  let token0: TestERC20;
-  let token1;
-  let swapTarget: TestAlgebraCallee;
 
   before('create fixture loader', async () => {
     [wallet, other] = await (ethers as any).getSigners();
@@ -71,10 +67,6 @@ describe('AlgebraPool gas tests [ @skip-on-coverage ]', () => {
           pool,
         });
 
-        token0 = fix.token0;
-        token1 = fix.token1;
-        swapTarget = fix.swapTargetCallee;
-
         await pool.initialize(encodePriceSqrt(1, 1));
         if (communityFee != 0) await pool.setCommunityFee(communityFee);
         await pool.advanceTime(1);
@@ -118,12 +110,12 @@ describe('AlgebraPool gas tests [ @skip-on-coverage ]', () => {
         });
 
         it('first swap in block moves tick, no initialized crossings', async () => {
-          await snapshotGasCost(swapExact1For0(expandTo18Decimals(1).div(10000), wallet.address));
+          await snapshotGasCost(swapExact1For0(expandTo18Decimals(1) / 10000n, wallet.address));
           expect((await pool.globalState()).tick).to.eq(startingTick + 1);
         });
 
         it('second swap in block with no tick movement', async () => {
-          await swapExact1For0(expandTo18Decimals(1).div(10000), wallet.address);
+          await swapExact1For0(expandTo18Decimals(1) / 10000n, wallet.address);
           expect((await pool.globalState()).tick).to.eq(startingTick + 1);
           await snapshotGasCost(swapExact1For0(2000, wallet.address));
           expect((await pool.globalState()).tick).to.eq(startingTick + 1);
@@ -138,12 +130,12 @@ describe('AlgebraPool gas tests [ @skip-on-coverage ]', () => {
         });
 
         it('first swap in block moves tick, no initialized crossings', async () => {
-          await snapshotGasCost(swapExact0For1(expandTo18Decimals(1).div(10000), wallet.address));
+          await snapshotGasCost(swapExact0For1(expandTo18Decimals(1) / 10000n, wallet.address));
           expect((await pool.globalState()).tick).to.eq(startingTick - 1);
         });
 
         it('second swap in block with no tick movement', async () => {
-          await swapExact0For1(expandTo18Decimals(1).div(10000), wallet.address);
+          await swapExact0For1(expandTo18Decimals(1) / 10000n, wallet.address);
           expect((await pool.globalState()).tick).to.eq(startingTick - 1);
           await snapshotGasCost(swapExact0For1(2000, wallet.address));
           expect((await pool.globalState()).tick).to.eq(startingTick - 1);
@@ -152,7 +144,7 @@ describe('AlgebraPool gas tests [ @skip-on-coverage ]', () => {
         it('second swap in block moves tick, no initialized crossings', async () => {
           await swapExact0For1(1000, wallet.address);
           expect((await pool.globalState()).tick).to.eq(startingTick);
-          await snapshotGasCost(swapExact0For1(expandTo18Decimals(1).div(10000), wallet.address));
+          await snapshotGasCost(swapExact0For1(expandTo18Decimals(1) / 10000n, wallet.address));
           expect((await pool.globalState()).tick).to.eq(startingTick - 1);
         });
 
@@ -183,17 +175,17 @@ describe('AlgebraPool gas tests [ @skip-on-coverage ]', () => {
             expandTo18Decimals(1)
           );
           expect((await pool.globalState()).tick).to.eq(startingTick);
-          await swapExact0For1(expandTo18Decimals(1).div(10000), wallet.address);
+          await swapExact0For1(expandTo18Decimals(1) / 10000n, wallet.address);
           await pool.advanceTime(60);
-          await swapExact0For1(expandTo18Decimals(1).div(10000), wallet.address);
+          await swapExact0For1(expandTo18Decimals(1) / 10000n, wallet.address);
           await pool.advanceTime(60 * 60);
-          await swapExact1For0(expandTo18Decimals(1).div(10000), wallet.address);
+          await swapExact1For0(expandTo18Decimals(1) / 10000n, wallet.address);
           await pool.advanceTime(60 * 60);
-          await swapExact0For1(expandTo18Decimals(1).div(10000), wallet.address);
+          await swapExact0For1(expandTo18Decimals(1) / 10000n, wallet.address);
           await pool.advanceTime(5 * 60 * 60);
-          await swapExact1For0(expandTo18Decimals(1).div(10000), wallet.address);
+          await swapExact1For0(expandTo18Decimals(1) / 10000n, wallet.address);
           await pool.advanceTime(19 * 60 * 60);
-          await swapExact1For0(expandTo18Decimals(1).div(10000), wallet.address);
+          await swapExact1For0(expandTo18Decimals(1) / 10000n, wallet.address);
           await pool.advanceTime(60);
           await snapshotGasCost(swapExact0For1(expandTo18Decimals(1), wallet.address));
           expect((await pool.globalState()).tick).to.be.lt(startingTick - 4 * tickSpacing); // we crossed the last tick
@@ -208,17 +200,17 @@ describe('AlgebraPool gas tests [ @skip-on-coverage ]', () => {
             expandTo18Decimals(1)
           );
           expect((await pool.globalState()).tick).to.eq(startingTick);
-          await swapExact0For1(expandTo18Decimals(1).div(10000), wallet.address);
+          await swapExact0For1(expandTo18Decimals(1) / 10000n, wallet.address);
           await pool.advanceTime(60);
-          await swapExact0For1(expandTo18Decimals(1).div(10000), wallet.address);
+          await swapExact0For1(expandTo18Decimals(1) / 10000n, wallet.address);
           await pool.advanceTime(60 * 60);
-          await swapExact1For0(expandTo18Decimals(1).div(10000), wallet.address);
+          await swapExact1For0(expandTo18Decimals(1) / 10000n, wallet.address);
           await pool.advanceTime(60 * 60);
-          await swapExact0For1(expandTo18Decimals(1).div(10000), wallet.address);
+          await swapExact0For1(expandTo18Decimals(1) / 10000n, wallet.address);
           await pool.advanceTime(5 * 60 * 60);
-          await swapExact1For0(expandTo18Decimals(1).div(10000), wallet.address);
+          await swapExact1For0(expandTo18Decimals(1) / 10000n, wallet.address);
           await pool.advanceTime(19 * 60 * 60);
-          await swapExact0For1(expandTo18Decimals(1).div(10000), wallet.address);
+          await swapExact0For1(expandTo18Decimals(1) / 10000n, wallet.address);
           await pool.advanceTime(60);
           await snapshotGasCost(swapExact0For1(1000, wallet.address));
           expect((await pool.globalState()).tick).to.be.lt(0);
@@ -235,9 +227,9 @@ describe('AlgebraPool gas tests [ @skip-on-coverage ]', () => {
           expect((await pool.globalState()).tick).to.eq(startingTick);
           for (let i = 0; i < 100; i++) {
             if (i % 2 == 0) {
-              await swapExact0For1(expandTo18Decimals(1).div(10000), wallet.address);
+              await swapExact0For1(expandTo18Decimals(1) / 10000n, wallet.address);
             } else {
-              await swapExact1For0(expandTo18Decimals(1).div(10000), wallet.address);
+              await swapExact1For0(expandTo18Decimals(1) / 10000n, wallet.address);
             }
             await pool.advanceTime(60 * 60);
           }
@@ -258,14 +250,14 @@ describe('AlgebraPool gas tests [ @skip-on-coverage ]', () => {
             startingTick - 2 * tickSpacing,
             expandTo18Decimals(1)
           );
-          await swapExact0For1(expandTo18Decimals(1).div(10000), wallet.address);
+          await swapExact0For1(expandTo18Decimals(1) / 10000n, wallet.address);
           await snapshotGasCost(swapExact0For1(expandTo18Decimals(1), wallet.address));
           expect((await pool.globalState()).tick).to.be.lt(startingTick - 4 * tickSpacing);
         });
 
         it('second swap in block, large swap crossing a single initialized tick', async () => {
           await mint(wallet.address, minTick, startingTick - 2 * tickSpacing, expandTo18Decimals(1));
-          await swapExact0For1(expandTo18Decimals(1).div(10000), wallet.address);
+          await swapExact0For1(expandTo18Decimals(1) / 10000n, wallet.address);
           expect((await pool.globalState()).tick).to.be.gt(startingTick - 2 * tickSpacing); // we didn't cross the initialized tick
           await snapshotGasCost(swapExact0For1(expandTo18Decimals(1), wallet.address));
           expect((await pool.globalState()).tick).to.be.lt(startingTick - 2 * tickSpacing); // we crossed the last tick
@@ -365,18 +357,18 @@ describe('AlgebraPool gas tests [ @skip-on-coverage ]', () => {
             });
 
             it('burn when only position using ticks', async () => {
-              await snapshotGasCost(pool.burn(bottomTick, topTick, expandTo18Decimals(1), []));
+              await snapshotGasCost(pool.burn(bottomTick, topTick, expandTo18Decimals(1), '0x'));
             });
             it('partial position burn', async () => {
-              await snapshotGasCost(pool.burn(bottomTick, topTick, expandTo18Decimals(1).div(2), []));
+              await snapshotGasCost(pool.burn(bottomTick, topTick, expandTo18Decimals(1) / 2n, '0x'));
             });
             it('entire position burn but other positions are using the ticks', async () => {
               await mint(other.address, bottomTick, topTick, expandTo18Decimals(1));
-              await snapshotGasCost(pool.burn(bottomTick, topTick, expandTo18Decimals(1), []));
+              await snapshotGasCost(pool.burn(bottomTick, topTick, expandTo18Decimals(1), '0x'));
             });
             it('burn entire position after some time passes', async () => {
               await pool.advanceTime(1);
-              await snapshotGasCost(pool.burn(bottomTick, topTick, expandTo18Decimals(1), []));
+              await snapshotGasCost(pool.burn(bottomTick, topTick, expandTo18Decimals(1), '0x'));
             });
           });
         }
@@ -388,10 +380,10 @@ describe('AlgebraPool gas tests [ @skip-on-coverage ]', () => {
 
         it('best case', async () => {
           await mint(wallet.address, bottomTick, topTick, expandTo18Decimals(1));
-          await swapExact0For1(expandTo18Decimals(1).div(100), wallet.address);
-          await pool.burn(bottomTick, topTick, 0, []);
-          await swapExact0For1(expandTo18Decimals(1).div(100), wallet.address);
-          await snapshotGasCost(pool.burn(bottomTick, topTick, 0, []));
+          await swapExact0For1(expandTo18Decimals(1)/ 100n, wallet.address);
+          await pool.burn(bottomTick, topTick, 0, '0x');
+          await swapExact0For1(expandTo18Decimals(1)/ 100n, wallet.address);
+          await snapshotGasCost(pool.burn(bottomTick, topTick, 0, '0x'));
         });
       });
 
@@ -401,16 +393,16 @@ describe('AlgebraPool gas tests [ @skip-on-coverage ]', () => {
 
         it('close to worst case', async () => {
           await mint(wallet.address, bottomTick, topTick, expandTo18Decimals(1));
-          await swapExact0For1(expandTo18Decimals(1).div(100), wallet.address);
-          await pool.burn(bottomTick, topTick, 0, []); // poke to accumulate fees
+          await swapExact0For1(expandTo18Decimals(1)/ 100n, wallet.address);
+          await pool.burn(bottomTick, topTick, 0, '0x'); // poke to accumulate fees
           await snapshotGasCost(pool.collect(wallet.address, bottomTick, topTick, MaxUint128, MaxUint128));
         });
 
         it('close to worst case, two tokens', async () => {
           await mint(wallet.address, bottomTick, topTick, expandTo18Decimals(1));
-          await swapExact0For1(expandTo18Decimals(1).div(100), wallet.address);
-          await swapExact1For0(expandTo18Decimals(1).div(100), wallet.address);
-          await pool.burn(bottomTick, topTick, 0, []); // poke to accumulate fees
+          await swapExact0For1(expandTo18Decimals(1)/ 100n, wallet.address);
+          await swapExact1For0(expandTo18Decimals(1)/ 100n, wallet.address);
+          await pool.burn(bottomTick, topTick, 0, '0x'); // poke to accumulate fees
           await snapshotGasCost(pool.collect(wallet.address, bottomTick, topTick, MaxUint128, MaxUint128));
         });
       });

--- a/src/core/test/AlgebraPool.spec.ts
+++ b/src/core/test/AlgebraPool.spec.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'hardhat';
-import { BigNumber, BigNumberish, constants, ContractReceipt, Wallet } from 'ethers';
+import { ContractTransactionReceipt, EventLog, Wallet, MaxUint256, ZeroAddress } from 'ethers';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from './shared/expect';
 
@@ -35,7 +35,6 @@ import {
   PriceMovementMathTest,
   IERC20Minimal,
 } from '../typechain';
-import { callback } from '../typechain/contracts/interfaces';
 
 type ThenArg<T> = T extends PromiseLike<infer U> ? U : T;
 
@@ -85,7 +84,7 @@ describe('AlgebraPool', () => {
       createPool: _createPool,
       swapTargetCallee: swapTarget,
     } = await loadFixture(poolFixture));
-    vaultAddress = vault.address;
+    vaultAddress = await vault.getAddress();
     createPoolWrapped = async () => {
       const pool = await _createPool();
       ({
@@ -114,10 +113,10 @@ describe('AlgebraPool', () => {
   });
 
   it('constructor initializes immutables', async () => {
-    expect(await pool.factory()).to.eq(factory.address);
-    expect(await pool.token0()).to.eq(token0.address);
-    expect(await pool.token1()).to.eq(token1.address);
-    expect(await pool.maxLiquidityPerTick()).to.eq(BigNumber.from('191757638537527648490752896198553'));
+    expect(await pool.factory()).to.eq(await factory.getAddress());
+    expect(await pool.token0()).to.eq(await token0.getAddress());
+    expect(await pool.token1()).to.eq(await token1.getAddress());
+    expect(await pool.maxLiquidityPerTick()).to.eq(BigInt('191757638537527648490752896198553'));
   });
 
   it('_blockTimestamp works', async () => {
@@ -131,11 +130,11 @@ describe('AlgebraPool', () => {
     });
     it('fails if starting price is too low', async () => {
       await expect(pool.initialize(1)).to.be.revertedWithCustomError(pool, 'priceOutOfRange');
-      await expect(pool.initialize(MIN_SQRT_RATIO.sub(1))).to.be.revertedWithCustomError(pool, 'priceOutOfRange');
+      await expect(pool.initialize(MIN_SQRT_RATIO - 1n)).to.be.revertedWithCustomError(pool, 'priceOutOfRange');
     });
     it('fails if starting price is too high', async () => {
       await expect(pool.initialize(MAX_SQRT_RATIO)).to.be.revertedWithCustomError(pool, 'priceOutOfRange');
-      await expect(pool.initialize(BigNumber.from(2).pow(160).sub(1))).to.be.revertedWithCustomError(
+      await expect(pool.initialize(2n ** 160n - 1n)).to.be.revertedWithCustomError(
         pool,
         'priceOutOfRange'
       );
@@ -145,7 +144,7 @@ describe('AlgebraPool', () => {
       expect((await pool.globalState()).tick).to.eq(getMinTick(1));
     });
     it('can be initialized at MAX_SQRT_RATIO - 1', async () => {
-      await pool.initialize(MAX_SQRT_RATIO.sub(1));
+      await pool.initialize(MAX_SQRT_RATIO- 1n);
       expect((await pool.globalState()).tick).to.eq(getMaxTick(1) - 1);
     });
     it('sets initial variables', async () => {
@@ -186,26 +185,26 @@ describe('AlgebraPool', () => {
           beforeEach(async () => {
             const factory = await ethers.getContractFactory('TestAlgebraSwapPay');
             payer = (await factory.deploy()) as TestAlgebraSwapPay;
-            await token0.approve(payer.address, BigNumber.from(2).pow(256).sub(1));
-            await token1.approve(payer.address, BigNumber.from(2).pow(256).sub(1));
+            await token0.approve(payer, 2n ** 256n - 1n);
+            await token1.approve(payer, 2n ** 256n - 1n);
           });
 
           it('fails if token0 payed 0', async () => {
             await expect(
-              payer.mint(pool.address, wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 100, 0, 100)
+              payer.mint(pool, wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 100, 0, 100)
             ).to.be.revertedWithCustomError(pool, 'zeroLiquidityActual');
             await expect(
-              payer.mint(pool.address, wallet.address, -22980, 0, 10000, 0, 100)
+              payer.mint(pool, wallet.address, -22980, 0, 10000, 0, 100)
             ).to.be.revertedWithCustomError(pool, 'zeroLiquidityActual');
           });
 
           it('fails if token1 payed 0', async () => {
             await expect(
-              payer.mint(pool.address, wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 100, 100, 0)
+              payer.mint(pool, wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 100, 100, 0)
             ).to.be.revertedWithCustomError(pool, 'zeroLiquidityActual');
             await expect(
               payer.mint(
-                pool.address,
+                pool,
                 wallet.address,
                 minTick + tickSpacing,
                 Math.floor((-23028 - tickSpacing) / tickSpacing) * tickSpacing,
@@ -219,7 +218,7 @@ describe('AlgebraPool', () => {
           it('fails if token0 hardly underpayed', async () => {
             await expect(
               payer.mint(
-                pool.address,
+                pool,
                 wallet.address,
                 minTick + tickSpacing,
                 maxTick - tickSpacing,
@@ -234,7 +233,7 @@ describe('AlgebraPool', () => {
             await swapToHigherPrice(encodePriceSqrt(10, 1), wallet.address);
             await expect(
               payer.mint(
-                pool.address,
+                pool,
                 wallet.address,
                 minTick + tickSpacing,
                 maxTick - tickSpacing,
@@ -263,7 +262,7 @@ describe('AlgebraPool', () => {
         it('fails if amount exceeds the max', async () => {
           const maxLiquidityGross = await pool.maxLiquidityPerTick();
           await expect(
-            mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, maxLiquidityGross.add(1))
+            mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, maxLiquidityGross + 1n)
           ).to.be.revertedWithCustomError(pool, 'liquidityOverflow');
           await expect(mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, maxLiquidityGross)).to.not.be
             .reverted;
@@ -273,15 +272,15 @@ describe('AlgebraPool', () => {
 
           const maxLiquidityGross = await pool.maxLiquidityPerTick();
           await expect(
-            mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, maxLiquidityGross.sub(1000).add(1))
+            mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, maxLiquidityGross- 1000n + 1n)
           ).to.be.revertedWithCustomError(pool, 'liquidityOverflow');
           await expect(
-            mint(wallet.address, minTick + tickSpacing * 2, maxTick - tickSpacing, maxLiquidityGross.sub(1000).add(1))
+            mint(wallet.address, minTick + tickSpacing * 2, maxTick - tickSpacing, maxLiquidityGross- 1000n + 1n)
           ).to.be.revertedWithCustomError(pool, 'liquidityOverflow');
           await expect(
-            mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing * 2, maxLiquidityGross.sub(1000).add(1))
+            mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing * 2, maxLiquidityGross- 1000n + 1n)
           ).to.be.revertedWithCustomError(pool, 'liquidityOverflow');
-          await expect(mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, maxLiquidityGross.sub(1000)))
+          await expect(mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, maxLiquidityGross- 1000n))
             .to.not.be.reverted;
         });
         it('fails if amount is 0', async () => {
@@ -294,15 +293,15 @@ describe('AlgebraPool', () => {
       describe('success cases', () => {
         afterEach('check reserves', async () => {
           const reserves = await pool.getReserves();
-          const balances = [await token0.balanceOf(pool.address), await token1.balanceOf(pool.address)];
+          const balances = [await token0.balanceOf(pool), await token1.balanceOf(pool)];
 
           expect(reserves[0]).to.be.eq(balances[0]);
           expect(reserves[1]).to.be.eq(balances[1]);
         })
 
         it('initial balances', async () => {
-          expect(await token0.balanceOf(pool.address)).to.eq(9996);
-          expect(await token1.balanceOf(pool.address)).to.eq(1000);
+          expect(await token0.balanceOf(pool)).to.eq(9996);
+          expect(await token1.balanceOf(pool)).to.eq(1000);
         });
 
         it('initial tick', async () => {
@@ -312,26 +311,29 @@ describe('AlgebraPool', () => {
         it('emits event', async () => {
           await expect(
             mint(wallet.address, 0, tickSpacing, expandTo18Decimals(1))
-          ).to.emit(pool, 'Mint').withArgs(swapTarget.address, wallet.address, 0, tickSpacing, expandTo18Decimals(1), '2995354955910781', 0);
+          ).to.emit(pool, 'Mint').withArgs(await swapTarget.getAddress(), wallet.address, 0, tickSpacing, expandTo18Decimals(1), '2995354955910781', 0);
         });
 
-        const hasRefund = (_receipt: ContractReceipt, _token: IERC20Minimal, to: string) => {
-          return _receipt.events?.some((x) => {
-            if (x.address != _token.address) return false;
+        const hasRefund = async (_receipt: ContractTransactionReceipt | null, _token: IERC20Minimal, to: string) => {
+          const tokenAddress = await _token.getAddress();
+          if (!_receipt) return false;
+          return _receipt.logs?.some((x) => {
+            if (x.address != tokenAddress) return false;
+            const decoded = _token.interface.parseLog({topics: [...x.topics], data: x.data});
+            if (!decoded) return false;
             
-            const decoded = _token.interface.parseLog(x);
-            return decoded.name == 'Transfer' && decoded.args && decoded.args["to"] == to;
+            return decoded.name == 'Transfer' && decoded.args && decoded.args[1] == to;
           })
         }
 
         it('refund if overpayment', async () => {
           const factory = await ethers.getContractFactory('TestAlgebraSwapPay');
           let payer = (await factory.deploy()) as TestAlgebraSwapPay;
-          await token0.approve(payer.address, BigNumber.from(2).pow(256).sub(1));
-          await token1.approve(payer.address, BigNumber.from(2).pow(256).sub(1));
+          await token0.approve(payer, 2n ** 256n - 1n);
+          await token1.approve(payer, 2n ** 256n - 1n);
 
           const receipt = await(await payer.mint(
-            pool.address,
+            pool,
             wallet.address,
             minTick + tickSpacing,
             maxTick - tickSpacing,
@@ -340,8 +342,8 @@ describe('AlgebraPool', () => {
             expandTo18Decimals(1000)
           )).wait();
 
-          const hasRefund0 = hasRefund(receipt, token0, wallet.address);
-          const hasRefund1 = hasRefund(receipt, token1, wallet.address);
+          const hasRefund0 = await hasRefund(receipt, token0, wallet.address);
+          const hasRefund1 = await hasRefund(receipt, token1, wallet.address);
 
           expect(hasRefund0).to.be.true;
           expect(hasRefund1).to.be.true;
@@ -350,8 +352,8 @@ describe('AlgebraPool', () => {
         it('do not refund if not overpaid', async () => {
           const factory = await ethers.getContractFactory('TestAlgebraSwapPay');
           let payer = (await factory.deploy()) as TestAlgebraSwapPay;
-          await token0.approve(payer.address, BigNumber.from(2).pow(256).sub(1));
-          await token1.approve(payer.address, BigNumber.from(2).pow(256).sub(1));
+          await token0.approve(payer, 2n ** 256n - 1n);
+          await token1.approve(payer, 2n ** 256n - 1n);
 
           const tx = await mint(
             wallet.address,
@@ -362,8 +364,8 @@ describe('AlgebraPool', () => {
 
           const receipt = await tx.wait();
 
-          const hasRefund0 = hasRefund(receipt, token0, wallet.address);
-          const hasRefund1 = hasRefund(receipt, token1, wallet.address);
+          const hasRefund0 = await hasRefund(receipt, token0, wallet.address);
+          const hasRefund1 = await hasRefund(receipt, token1, wallet.address);
 
           expect(hasRefund0).to.be.false;
           expect(hasRefund1).to.be.false;
@@ -375,32 +377,32 @@ describe('AlgebraPool', () => {
           beforeEach(async () => {
             const factory = await ethers.getContractFactory('TestAlgebraSwapPay');
             payer = (await factory.deploy()) as TestAlgebraSwapPay;
-            await token0.approve(payer.address, BigNumber.from(2).pow(256).sub(1));
-            await token1.approve(payer.address, BigNumber.from(2).pow(256).sub(1));
+            await token0.approve(payer, 2n ** 256n - 1n);
+            await token1.approve(payer, 2n ** 256n - 1n);
           });
 
           it('handle underpayment in both tokens', async () => {
             await expect(
-              payer.mint(pool.address, wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 1000000, 100, 100)
+              payer.mint(pool, wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 1000000, 100, 100)
             ).to.not.be.reverted;
           });
 
           it('handle underpayment in both tokens, token0 less', async () => {
             await expect(
-              payer.mint(pool.address, wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 1000000, 50, 100)
+              payer.mint(pool, wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 1000000, 50, 100)
             ).to.not.be.reverted;
           });
 
           it('handle underpayment in both tokens, token1 less', async () => {
             await expect(
-              payer.mint(pool.address, wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 1000000, 100, 50)
+              payer.mint(pool, wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 1000000, 100, 50)
             ).to.not.be.reverted;
           });
 
           it('handle underpayment in token0', async () => {
             await expect(
               payer.mint(
-                pool.address,
+                pool,
                 wallet.address,
                 minTick + tickSpacing,
                 maxTick - tickSpacing,
@@ -414,7 +416,7 @@ describe('AlgebraPool', () => {
           it('handle underpayment in token1', async () => {
             await expect(
               payer.mint(
-                pool.address,
+                pool,
                 wallet.address,
                 minTick + tickSpacing,
                 maxTick - tickSpacing,
@@ -428,40 +430,41 @@ describe('AlgebraPool', () => {
 
         describe('above current price', () => {
           it('transfers token0 only', async () => {
+            const poolAddress = await pool.getAddress();
             await expect(mint(wallet.address, -22980, 0, 10000))
               .to.emit(token0, 'Transfer')
-              .withArgs(wallet.address, pool.address, 21549)
+              .withArgs(wallet.address, poolAddress, 21549)
               .to.not.emit(token1, 'Transfer');
-            expect(await token0.balanceOf(pool.address)).to.eq(9996 + 21549);
-            expect(await token1.balanceOf(pool.address)).to.eq(1000);
+            expect(await token0.balanceOf(pool)).to.eq(9996 + 21549);
+            expect(await token1.balanceOf(pool)).to.eq(1000);
           });
 
           it('max tick with max leverage', async () => {
-            await mint(wallet.address, maxTick - tickSpacing, maxTick, BigNumber.from(2).pow(102));
-            expect(await token0.balanceOf(pool.address)).to.eq(9996 + 828011525);
-            expect(await token1.balanceOf(pool.address)).to.eq(1000);
+            await mint(wallet.address, maxTick - tickSpacing, maxTick, 2n ** 102n);
+            expect(await token0.balanceOf(pool)).to.eq(9996 + 828011525);
+            expect(await token1.balanceOf(pool)).to.eq(1000);
           });
 
           it('works for max tick', async () => {
             await expect(mint(wallet.address, -22980, maxTick, 10000))
               .to.emit(token0, 'Transfer')
-              .withArgs(wallet.address, pool.address, 31549);
-            expect(await token0.balanceOf(pool.address)).to.eq(9996 + 31549);
-            expect(await token1.balanceOf(pool.address)).to.eq(1000);
+              .withArgs(wallet.address, await pool.getAddress(), 31549);
+            expect(await token0.balanceOf(pool)).to.eq(9996 + 31549);
+            expect(await token1.balanceOf(pool)).to.eq(1000);
           });
 
           it('removing works', async () => {
             await mint(wallet.address, -240, 0, 10000);
-            await pool.burn(-240, 0, 10000, []);
-            const { amount0, amount1 } = await pool.callStatic.collect(wallet.address, -240, 0, MaxUint128, MaxUint128);
+            await pool.burn(-240, 0, 10000, '0x');
+            const { amount0, amount1 } = await pool.collect.staticCall(wallet.address, -240, 0, MaxUint128, MaxUint128);
             expect(amount0, 'amount0').to.eq(120);
             expect(amount1, 'amount1').to.eq(0);
           });
 
           it('removing works with min amounts', async () => {
             await mint(wallet.address, -240, 0, 10000);
-            await pool.burn(-240, 0, 10000, []);
-            const { amount0, amount1 } = await pool.callStatic.collect(wallet.address, -240, 0, 1, 1);
+            await pool.burn(-240, 0, 10000, '0x');
+            const { amount0, amount1 } = await pool.collect.staticCall(wallet.address, -240, 0, 1, 1);
             expect(amount0, 'amount0').to.eq(1);
             expect(amount1, 'amount1').to.eq(0);
           });
@@ -469,8 +472,8 @@ describe('AlgebraPool', () => {
           it('removing works after tickSpacing increase', async () => {
             await mint(wallet.address, -240, 0, 10000);
             await pool.setTickSpacing(100);
-            await pool.burn(-240, 0, 10000, []);
-            const { amount0, amount1 } = await pool.callStatic.collect(wallet.address, -240, 0, MaxUint128, MaxUint128);
+            await pool.burn(-240, 0, 10000, '0x');
+            const { amount0, amount1 } = await pool.collect.staticCall(wallet.address, -240, 0, MaxUint128, MaxUint128);
             expect(amount0, 'amount0').to.eq(120);
             expect(amount1, 'amount1').to.eq(0);
           });
@@ -478,8 +481,8 @@ describe('AlgebraPool', () => {
           it('removing works after tickSpacing decrease', async () => {
             await mint(wallet.address, -240, 0, 10000);
             await pool.setTickSpacing(1);
-            await pool.burn(-240, 0, 10000, []);
-            const { amount0, amount1 } = await pool.callStatic.collect(wallet.address, -240, 0, MaxUint128, MaxUint128);
+            await pool.burn(-240, 0, 10000, '0x');
+            const { amount0, amount1 } = await pool.collect.staticCall(wallet.address, -240, 0, MaxUint128, MaxUint128);
             expect(amount0, 'amount0').to.eq(120);
             expect(amount1, 'amount1').to.eq(0);
           });
@@ -505,14 +508,14 @@ describe('AlgebraPool', () => {
           it('removes liquidity from liquidityTotal', async () => {
             await mint(wallet.address, -240, 0, 100);
             await mint(wallet.address, -240, 0, 40);
-            await pool.burn(-240, 0, 90, []);
+            await pool.burn(-240, 0, 90, '0x');
             expect((await pool.ticks(-240)).liquidityTotal).to.eq(50);
             expect((await pool.ticks(0)).liquidityTotal).to.eq(50);
           });
 
           it('clears tick lower if last position is removed', async () => {
             await mint(wallet.address, -240, 0, 100);
-            await pool.burn(-240, 0, 100, []);
+            await pool.burn(-240, 0, 100, '0x');
             const { liquidityTotal, outerFeeGrowth0Token, outerFeeGrowth1Token } = await pool.ticks(-240);
             expect(liquidityTotal).to.eq(0);
             expect(outerFeeGrowth0Token).to.eq(0);
@@ -521,7 +524,7 @@ describe('AlgebraPool', () => {
 
           it('clears tick upper if last position is removed', async () => {
             await mint(wallet.address, -240, 0, 100);
-            await pool.burn(-240, 0, 100, []);
+            await pool.burn(-240, 0, 100, '0x');
             const { liquidityTotal, outerFeeGrowth0Token, outerFeeGrowth1Token } = await pool.ticks(0);
             expect(liquidityTotal).to.eq(0);
             expect(outerFeeGrowth0Token).to.eq(0);
@@ -530,7 +533,7 @@ describe('AlgebraPool', () => {
           it('only clears the tick that is not used at all', async () => {
             await mint(wallet.address, -240, 0, 100);
             await mint(wallet.address, -tickSpacing, 0, 250);
-            await pool.burn(-240, 0, 100, []);
+            await pool.burn(-240, 0, 100, '0x');
 
             let { liquidityTotal, outerFeeGrowth0Token, outerFeeGrowth1Token } = await pool.ticks(-240);
             expect(liquidityTotal).to.eq(0);
@@ -545,13 +548,14 @@ describe('AlgebraPool', () => {
 
         describe('including current price', () => {
           it('price within range: transfers current price of both tokens', async () => {
+            const poolAddress = await pool.getAddress();
             await expect(mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 100))
               .to.emit(token0, 'Transfer')
-              .withArgs(wallet.address, pool.address, 317)
+              .withArgs(wallet.address, poolAddress, 317)
               .to.emit(token1, 'Transfer')
-              .withArgs(wallet.address, pool.address, 32);
-            expect(await token0.balanceOf(pool.address)).to.eq(9996 + 317);
-            expect(await token1.balanceOf(pool.address)).to.eq(1000 + 32);
+              .withArgs(wallet.address, poolAddress, 32);
+            expect(await token0.balanceOf(pool)).to.eq(9996 + 317);
+            expect(await token1.balanceOf(pool)).to.eq(1000 + 32);
           });
 
           it('initializes lower tick', async () => {
@@ -567,19 +571,20 @@ describe('AlgebraPool', () => {
           });
 
           it('works for min/max tick', async () => {
+            const poolAddress = await pool.getAddress();
             await expect(mint(wallet.address, minTick, maxTick, 10000))
               .to.emit(token0, 'Transfer')
-              .withArgs(wallet.address, pool.address, 31623)
+              .withArgs(wallet.address, poolAddress, 31623)
               .to.emit(token1, 'Transfer')
-              .withArgs(wallet.address, pool.address, 3163);
-            expect(await token0.balanceOf(pool.address)).to.eq(9996 + 31623);
-            expect(await token1.balanceOf(pool.address)).to.eq(1000 + 3163);
+              .withArgs(wallet.address, poolAddress, 3163);
+            expect(await token0.balanceOf(pool)).to.eq(9996 + 31623);
+            expect(await token1.balanceOf(pool)).to.eq(1000 + 3163);
           });
 
           it('removing works', async () => {
             await mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 100);
-            await pool.burn(minTick + tickSpacing, maxTick - tickSpacing, 100, []);
-            const { amount0, amount1 } = await pool.callStatic.collect(
+            await pool.burn(minTick + tickSpacing, maxTick - tickSpacing, 100, '0x');
+            const { amount0, amount1 } = await pool.collect.staticCall(
               wallet.address,
               minTick + tickSpacing,
               maxTick - tickSpacing,
@@ -595,30 +600,30 @@ describe('AlgebraPool', () => {
           it('transfers token1 only', async () => {
             await expect(mint(wallet.address, -46080, -23040, 10000))
               .to.emit(token1, 'Transfer')
-              .withArgs(wallet.address, pool.address, 2162)
+              .withArgs(wallet.address, await pool.getAddress(), 2162)
               .to.not.emit(token0, 'Transfer');
-            expect(await token0.balanceOf(pool.address)).to.eq(9996);
-            expect(await token1.balanceOf(pool.address)).to.eq(1000 + 2162);
+            expect(await token0.balanceOf(pool)).to.eq(9996);
+            expect(await token1.balanceOf(pool)).to.eq(1000 + 2162);
           });
 
           it('min tick with max leverage', async () => {
-            await mint(wallet.address, minTick, minTick + tickSpacing, BigNumber.from(2).pow(102));
-            expect(await token0.balanceOf(pool.address)).to.eq(9996);
-            expect(await token1.balanceOf(pool.address)).to.eq(1000 + 828011520);
+            await mint(wallet.address, minTick, minTick + tickSpacing, 2n ** 102n);
+            expect(await token0.balanceOf(pool)).to.eq(9996);
+            expect(await token1.balanceOf(pool)).to.eq(1000 + 828011520);
           });
 
           it('works for min tick', async () => {
             await expect(mint(wallet.address, minTick, -23040, 10000))
               .to.emit(token1, 'Transfer')
-              .withArgs(wallet.address, pool.address, 3161);
-            expect(await token0.balanceOf(pool.address)).to.eq(9996);
-            expect(await token1.balanceOf(pool.address)).to.eq(1000 + 3161);
+              .withArgs(wallet.address, await pool.getAddress(), 3161);
+            expect(await token0.balanceOf(pool)).to.eq(9996);
+            expect(await token1.balanceOf(pool)).to.eq(1000 + 3161);
           });
 
           it('removing works', async () => {
             await mint(wallet.address, -46080, -46020, 10000);
-            await pool.burn(-46080, -46020, 10000, []);
-            const { amount0, amount1 } = await pool.callStatic.collect(
+            await pool.burn(-46080, -46020, 10000, '0x');
+            const { amount0, amount1 } = await pool.collect.staticCall(
               wallet.address,
               -46080,
               -46020,
@@ -635,8 +640,8 @@ describe('AlgebraPool', () => {
         await pool.setCommunityFee(170);
 
         await mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, expandTo18Decimals(1));
-        await swapExact0For1(expandTo18Decimals(1).div(10), wallet.address);
-        await swapExact1For0(expandTo18Decimals(1).div(100), wallet.address);
+        await swapExact0For1(expandTo18Decimals(1) / 10n, wallet.address);
+        await swapExact1For0(expandTo18Decimals(1) / 100n, wallet.address);
 
         expect((await token0.balanceOf(vaultAddress)).toString()).to.eq('1700000000000');
         const [, communityFeePending1] = await pool.getCommunityFeePending();
@@ -645,8 +650,8 @@ describe('AlgebraPool', () => {
 
       it('positions are protected before community fee is turned on', async () => {
         await mint(wallet.address, minTick + tickSpacing, maxTick - tickSpacing, expandTo18Decimals(1));
-        await swapExact0For1(expandTo18Decimals(1).div(10), wallet.address);
-        await swapExact1For0(expandTo18Decimals(1).div(100), wallet.address);
+        await swapExact0For1(expandTo18Decimals(1) / 10n, wallet.address);
+        await swapExact1For0(expandTo18Decimals(1) / 100n, wallet.address);
 
         expect(Number((await token0.balanceOf(vaultAddress)).toString())).to.eq(0);
         expect(Number((await token1.balanceOf(vaultAddress)).toString())).to.eq(0);
@@ -658,10 +663,10 @@ describe('AlgebraPool', () => {
 
       it('poke is not happened on uninitialized position', async () => {
         await mint(other.address, minTick + tickSpacing, maxTick - tickSpacing, expandTo18Decimals(1));
-        await swapExact0For1(expandTo18Decimals(1).div(10), wallet.address);
-        await swapExact1For0(expandTo18Decimals(1).div(100), wallet.address);
+        await swapExact0For1(expandTo18Decimals(1) / 10n, wallet.address);
+        await swapExact1For0(expandTo18Decimals(1) / 100n, wallet.address);
 
-        await expect(pool.burn(minTick + tickSpacing, maxTick - tickSpacing, 0, [])).to.be.not.reverted;
+        await expect(pool.burn(minTick + tickSpacing, maxTick - tickSpacing, 0, '0x')).to.be.not.reverted;
         let {
           liquidity: l0,
           innerFeeGrowth0Token: ifg0,
@@ -688,7 +693,7 @@ describe('AlgebraPool', () => {
         expect(innerFeeGrowth0Token).to.eq('3402823669209373878308127703486852');
         expect(innerFeeGrowth1Token).to.eq('340282366920937387830812770348685');
 
-        await pool.burn(minTick + tickSpacing, maxTick - tickSpacing, 1, []);
+        await pool.burn(minTick + tickSpacing, maxTick - tickSpacing, 1, '0x');
         ({ liquidity, innerFeeGrowth0Token, innerFeeGrowth1Token, fees1, fees0 } = await pool.positions(
           await pool.getKeyForPosition(wallet.address, minTick + tickSpacing, maxTick - tickSpacing)
         ));
@@ -723,7 +728,7 @@ describe('AlgebraPool', () => {
       await mint(other.address, minTick, maxTick, expandTo18Decimals(1));
       await swapExact0For1(expandTo18Decimals(1), wallet.address);
       await swapExact1For0(expandTo18Decimals(1), wallet.address);
-      await pool.connect(other).burn(minTick, maxTick, expandTo18Decimals(1), []);
+      await pool.connect(other).burn(minTick, maxTick, expandTo18Decimals(1), '0x');
       const { liquidity, fees0, fees1, innerFeeGrowth0Token, innerFeeGrowth1Token } = await pool.positions(
         await pool.getKeyForPosition(other.address, minTick, maxTick)
       );
@@ -741,7 +746,7 @@ describe('AlgebraPool', () => {
       await pool.advanceTime(10);
       await mint(wallet.address, bottomTick, topTick, 1);
       await swapExact0For1(expandTo18Decimals(1), wallet.address);
-      await pool.burn(bottomTick, topTick, 1, []);
+      await pool.burn(bottomTick, topTick, 1, '0x');
       await checkTickIsClear(bottomTick);
       await checkTickIsClear(topTick);
     });
@@ -754,7 +759,7 @@ describe('AlgebraPool', () => {
       await mint(wallet.address, bottomTick, topTick, 1);
       await swapExact0For1(expandTo18Decimals(1), wallet.address);
       await pool.setTickSpacing(200);
-      await pool.burn(bottomTick, topTick, 1, []);
+      await pool.burn(bottomTick, topTick, 1, '0x');
       await checkTickIsClear(bottomTick);
       await checkTickIsClear(topTick);
     });
@@ -767,7 +772,7 @@ describe('AlgebraPool', () => {
       await mint(wallet.address, bottomTick, topTick, 1);
       await mint(wallet.address, bottomTick + tickSpacing, topTick, 1);
       await swapExact0For1(expandTo18Decimals(1), wallet.address);
-      await pool.burn(bottomTick, topTick, 1, []);
+      await pool.burn(bottomTick, topTick, 1, '0x');
       await checkTickIsClear(bottomTick);
       await checkTickIsNotClear(topTick);
     });
@@ -781,7 +786,7 @@ describe('AlgebraPool', () => {
       await mint(wallet.address, bottomTick + tickSpacing, topTick, 1);
       await pool.setTickSpacing(5);
       await swapExact0For1(expandTo18Decimals(1), wallet.address);
-      await pool.burn(bottomTick, topTick, 1, []);
+      await pool.burn(bottomTick, topTick, 1, '0x');
       await checkTickIsClear(bottomTick);
       await checkTickIsNotClear(topTick);
     });
@@ -794,7 +799,7 @@ describe('AlgebraPool', () => {
       await mint(wallet.address, bottomTick, topTick, 1);
       await mint(wallet.address, bottomTick, topTick - tickSpacing, 1);
       await swapExact0For1(expandTo18Decimals(1), wallet.address);
-      await pool.burn(bottomTick, topTick, 1, []);
+      await pool.burn(bottomTick, topTick, 1, '0x');
       await checkTickIsNotClear(bottomTick);
       await checkTickIsClear(topTick);
     });
@@ -808,7 +813,7 @@ describe('AlgebraPool', () => {
       await mint(wallet.address, bottomTick, topTick - tickSpacing, 1);
       await pool.setTickSpacing(100);
       await swapExact0For1(expandTo18Decimals(1), wallet.address);
-      await pool.burn(bottomTick, topTick, 1, []);
+      await pool.burn(bottomTick, topTick, 1, '0x');
       await checkTickIsNotClear(bottomTick);
       await checkTickIsClear(topTick);
     });
@@ -820,7 +825,7 @@ describe('AlgebraPool', () => {
       await pool.advanceTime(10);
       await mint(wallet.address, bottomTick, topTick, 1);
       await swapExact0For1(expandTo18Decimals(1), wallet.address);
-      await expect(pool.burn(topTick, bottomTick, 1, [])).to.be.revertedWithCustomError(
+      await expect(pool.burn(topTick, bottomTick, 1, '0x')).to.be.revertedWithCustomError(
         pool,
         'topTickLowerOrEqBottomTick'
       );
@@ -833,7 +838,7 @@ describe('AlgebraPool', () => {
       await pool.advanceTime(10);
       await mint(wallet.address, bottomTick, topTick, 1);
       await swapExact0For1(expandTo18Decimals(1), wallet.address);
-      await expect(pool.burn(bottomTick, topTick, BigNumber.from(2).pow(128).sub(1), [])).to.be.revertedWithCustomError(
+      await expect(pool.burn(bottomTick, topTick, 2n ** 128n - 1n, '0x')).to.be.revertedWithCustomError(
         pool,
         'arithmeticError'
       );
@@ -844,7 +849,7 @@ describe('AlgebraPool', () => {
       const topTick = maxTick - 2*tickSpacing;
       // some activity that would make the ticks non-zero
       await pool.advanceTime(10);
-      await expect(pool.burn(bottomTick, topTick, 0, [])).to.not.emit(pool, 'Burn');
+      await expect(pool.burn(bottomTick, topTick, 0, '0x')).to.not.emit(pool, 'Burn');
     });
   });
 
@@ -852,7 +857,7 @@ describe('AlgebraPool', () => {
   const initializeLiquidityAmount = expandTo18Decimals(2);
   async function initializeAtZeroTick(pool: MockTimeAlgebraPool): Promise<void> {
     await pool.initialize(encodePriceSqrt(1, 1));
-    const tickSpacing = await pool.tickSpacing();
+    const tickSpacing = Number(await pool.tickSpacing());
     const [min, max] = [getMinTick(tickSpacing), getMaxTick(tickSpacing)];
     await mint(wallet.address, min, max, initializeLiquidityAmount);
   }
@@ -870,16 +875,16 @@ describe('AlgebraPool', () => {
 
       const liquidityBefore = await pool.liquidity();
 
-      const b0 = await token0.balanceOf(pool.address);
-      const b1 = await token1.balanceOf(pool.address);
+      const b0 = await token0.balanceOf(pool);
+      const b1 = await token1.balanceOf(pool);
 
       await mint(wallet.address, bottomTick, topTick, liquidityDelta);
 
       const liquidityAfter = await pool.liquidity();
       expect(liquidityAfter).to.be.gte(liquidityBefore);
 
-      expect((await token0.balanceOf(pool.address)).sub(b0)).to.eq(3);
-      expect((await token1.balanceOf(pool.address)).sub(b1)).to.eq(0);
+      expect((await token0.balanceOf(pool)) - b0).to.eq(3);
+      expect((await token1.balanceOf(pool)) - b1).to.eq(0);
     });
 
     it('mint to the left of the current price', async () => {
@@ -889,16 +894,16 @@ describe('AlgebraPool', () => {
 
       const liquidityBefore = await pool.liquidity();
 
-      const b0 = await token0.balanceOf(pool.address);
-      const b1 = await token1.balanceOf(pool.address);
+      const b0 = await token0.balanceOf(pool);
+      const b1 = await token1.balanceOf(pool);
 
       await mint(wallet.address, bottomTick, topTick, liquidityDelta);
 
       const liquidityAfter = await pool.liquidity();
       expect(liquidityAfter).to.be.gte(liquidityBefore);
 
-      expect((await token0.balanceOf(pool.address)).sub(b0)).to.eq(0);
-      expect((await token1.balanceOf(pool.address)).sub(b1)).to.eq(3);
+      expect((await token0.balanceOf(pool)) - b0).to.eq(0);
+      expect((await token1.balanceOf(pool)) - b1).to.eq(3);
     });
 
     it('mint within the current price', async () => {
@@ -908,23 +913,23 @@ describe('AlgebraPool', () => {
 
       const liquidityBefore = await pool.liquidity();
 
-      const b0 = await token0.balanceOf(pool.address);
-      const b1 = await token1.balanceOf(pool.address);
+      const b0 = await token0.balanceOf(pool);
+      const b1 = await token1.balanceOf(pool);
 
       await mint(wallet.address, bottomTick, topTick, liquidityDelta);
 
       const liquidityAfter = await pool.liquidity();
       expect(liquidityAfter).to.be.gte(liquidityBefore);
 
-      expect((await token0.balanceOf(pool.address)).sub(b0)).to.eq(3);
-      expect((await token1.balanceOf(pool.address)).sub(b1)).to.eq(3);
+      expect((await token0.balanceOf(pool)) - b0).to.eq(3);
+      expect((await token1.balanceOf(pool)) - b1).to.eq(3);
     });
 
     it('cannot remove more than the entire position', async () => {
       const bottomTick = -tickSpacing;
       const topTick = tickSpacing;
       await mint(wallet.address, bottomTick, topTick, expandTo18Decimals(1000));
-      await expect(pool.burn(bottomTick, topTick, expandTo18Decimals(1001), [])).to.be.revertedWithCustomError(
+      await expect(pool.burn(bottomTick, topTick, expandTo18Decimals(1001), '0x')).to.be.revertedWithCustomError(
         pool,
         'liquiditySub'
       );
@@ -945,16 +950,16 @@ describe('AlgebraPool', () => {
       const liquidityAfter = await pool.liquidity();
       expect(liquidityAfter, 'k increases').to.be.gte(liquidityBefore);
 
-      const token0BalanceBeforePool = await token0.balanceOf(pool.address);
-      const token1BalanceBeforePool = await token1.balanceOf(pool.address);
+      const token0BalanceBeforePool = await token0.balanceOf(pool);
+      const token1BalanceBeforePool = await token1.balanceOf(pool);
       const token0BalanceBeforeWallet = await token0.balanceOf(wallet.address);
       const token1BalanceBeforeWallet = await token1.balanceOf(wallet.address);
 
-      await pool.burn(bottomTick, topTick, 0, []);
+      await pool.burn(bottomTick, topTick, 0, '0x');
       await pool.collect(wallet.address, bottomTick, topTick, MaxUint128, MaxUint128);
 
-      await pool.burn(bottomTick, topTick, 0, []);
-      const { amount0: fees0, amount1: fees1 } = await pool.callStatic.collect(
+      await pool.burn(bottomTick, topTick, 0, '0x');
+      const { amount0: fees0, amount1: fees1 } = await pool.collect.staticCall(
         wallet.address,
         bottomTick,
         topTick,
@@ -966,8 +971,8 @@ describe('AlgebraPool', () => {
 
       const token0BalanceAfterWallet = await token0.balanceOf(wallet.address);
       const token1BalanceAfterWallet = await token1.balanceOf(wallet.address);
-      const token0BalanceAfterPool = await token0.balanceOf(pool.address);
-      const token1BalanceAfterPool = await token1.balanceOf(pool.address);
+      const token0BalanceAfterPool = await token0.balanceOf(pool);
+      const token1BalanceAfterPool = await token1.balanceOf(pool);
 
       expect(token0BalanceAfterWallet).to.be.gt(token0BalanceBeforeWallet);
       expect(token1BalanceAfterWallet).to.be.eq(token1BalanceBeforeWallet);
@@ -1052,71 +1057,75 @@ describe('AlgebraPool', () => {
     beforeEach('initialize at tick 0', () => initializeAtZeroTick(pool));
 
     it('limit selling 0 for 1 at tick 0 thru 1', async () => {
+      const poolAddress = await pool.getAddress();
       await expect(mint(wallet.address, 0, 120, expandTo18Decimals(1)))
         .to.emit(token0, 'Transfer')
-        .withArgs(wallet.address, pool.address, '5981737760509663');
+        .withArgs(wallet.address, poolAddress, '5981737760509663');
       // somebody takes the limit order
       await swapExact1For0(expandTo18Decimals(2), other.address);
-      await expect(pool.burn(0, 120, expandTo18Decimals(1), []))
+      await expect(pool.burn(0, 120, expandTo18Decimals(1), '0x'))
         .to.emit(pool, 'Burn')
         .withArgs(wallet.address, 0, 120, expandTo18Decimals(1), 0, '6017734268818165')
         .to.not.emit(token0, 'Transfer')
         .to.not.emit(token1, 'Transfer');
       await expect(pool.collect(wallet.address, 0, 120, MaxUint128, MaxUint128))
         .to.emit(token1, 'Transfer')
-        .withArgs(pool.address, wallet.address, BigNumber.from('6018336102428407')) // roughly 0.3% despite other liquidity
+        .withArgs(poolAddress, wallet.address, BigInt('6018336102428407')) // roughly 0.3% despite other liquidity
         .to.not.emit(token0, 'Transfer');
       expect((await pool.globalState()).tick).to.be.gte(120);
     });
     it('limit selling 1 for 0 at tick 0 thru -1', async () => {
+      const poolAddress = await pool.getAddress();
       await expect(mint(wallet.address, -120, 0, expandTo18Decimals(1)))
         .to.emit(token1, 'Transfer')
-        .withArgs(wallet.address, pool.address, '5981737760509663');
+        .withArgs(wallet.address, poolAddress, '5981737760509663');
       // somebody takes the limit order
       await swapExact0For1(expandTo18Decimals(2), other.address);
-      await expect(pool.burn(-120, 0, expandTo18Decimals(1), []))
+      await expect(pool.burn(-120, 0, expandTo18Decimals(1), '0x'))
         .to.emit(pool, 'Burn')
         .withArgs(wallet.address, -120, 0, expandTo18Decimals(1), '6017734268818165', 0)
         .to.not.emit(token0, 'Transfer')
         .to.not.emit(token1, 'Transfer');
       await expect(pool.collect(wallet.address, -120, 0, MaxUint128, MaxUint128))
         .to.emit(token0, 'Transfer')
-        .withArgs(pool.address, wallet.address, BigNumber.from('6018336102428407')); // roughly 0.3% despite other liquidity
+        .withArgs(poolAddress, wallet.address, BigInt('6018336102428407')); // roughly 0.3% despite other liquidity
       expect((await pool.globalState()).tick).to.be.lt(-120);
     });
 
     describe('fee is on', () => {
       beforeEach(() => pool.setCommunityFee(170));
       it('limit selling 0 for 1 at tick 0 thru 1', async () => {
+        const poolAddress = await pool.getAddress();
         await expect(mint(wallet.address, 0, 120, expandTo18Decimals(1)))
           .to.emit(token0, 'Transfer')
-          .withArgs(wallet.address, pool.address, '5981737760509663');
+          .withArgs(wallet.address, poolAddress, '5981737760509663');
         // somebody takes the limit order
         await swapExact1For0(expandTo18Decimals(2), other.address);
-        await expect(pool.burn(0, 120, expandTo18Decimals(1), []))
+        await expect(pool.burn(0, 120, expandTo18Decimals(1), '0x'))
           .to.emit(pool, 'Burn')
           .withArgs(wallet.address, 0, 120, expandTo18Decimals(1), 0, '6017734268818165')
           .to.not.emit(token0, 'Transfer')
           .to.not.emit(token1, 'Transfer');
         await expect(pool.collect(wallet.address, 0, 120, MaxUint128, MaxUint128))
           .to.emit(token1, 'Transfer')
-          .withArgs(pool.address, wallet.address, BigNumber.from('6017734268818165').add('499521896501'));
+          .withArgs(poolAddress, wallet.address, BigInt('6017734268818165') + 499521896501n);
         expect((await pool.globalState()).tick).to.be.gte(120);
       });
       it('limit selling 1 for 0 at tick 0 thru -1', async () => {
+        const poolAddress = await pool.getAddress();
         await expect(mint(wallet.address, -120, 0, expandTo18Decimals(1)))
           .to.emit(token1, 'Transfer')
-          .withArgs(wallet.address, pool.address, '5981737760509663');
+          .withArgs(wallet.address, poolAddress, '5981737760509663');
         // somebody takes the limit order
         await swapExact0For1(expandTo18Decimals(2), other.address);
-        await expect(pool.burn(-120, 0, expandTo18Decimals(1), []))
+        await expect(pool.burn(-120, 0, expandTo18Decimals(1), '0x'))
           .to.emit(pool, 'Burn')
           .withArgs(wallet.address, -120, 0, expandTo18Decimals(1), '6017734268818165', 0)
           .to.not.emit(token0, 'Transfer')
           .to.not.emit(token1, 'Transfer');
         await expect(pool.collect(wallet.address, -120, 0, MaxUint128, MaxUint128))
           .to.emit(token0, 'Transfer')
-          .withArgs(pool.address, wallet.address, BigNumber.from('6017734268818165').add('499521896501'));
+          .withArgs(poolAddress, wallet.address, BigInt('6017734268818165') + 499521896501n);
         expect((await pool.globalState()).tick).to.be.lt(-120);
       });
     });
@@ -1140,7 +1149,7 @@ describe('AlgebraPool', () => {
               true,
               '-57896044618658097711785492504343953926634992332820282019728792003956564819968',
               0,
-              []
+              '0x'
             )
           ).to.be.revertedWithCustomError(pool, 'invalidAmountRequired');
         });
@@ -1159,7 +1168,7 @@ describe('AlgebraPool', () => {
 
         it('fails if required negative amount', async () => {
           await expect(
-            pool.swapWithPaymentInAdvance(other.address, other.address, true, '-1', 0, [])
+            pool.swapWithPaymentInAdvance(other.address, other.address, true, '-1', 0, '0x')
           ).to.be.revertedWithCustomError(pool, 'invalidAmountRequired');
         });
 
@@ -1183,7 +1192,7 @@ describe('AlgebraPool', () => {
 
     afterEach('check reserves', async () => {
       const reserves = await pool.getReserves();
-      const balances = [await token0.balanceOf(pool.address), await token1.balanceOf(pool.address)];
+      const balances = [await token0.balanceOf(pool), await token1.balanceOf(pool)];
 
       expect(reserves[0]).to.be.eq(balances[0]);
       expect(reserves[1]).to.be.eq(balances[1]);
@@ -1195,8 +1204,8 @@ describe('AlgebraPool', () => {
 
       await swapExact0For1(expandTo18Decimals(1), wallet.address);
       // poke positions
-      await pool.burn(minTick, maxTick, 0, []);
-      await pool.burn(minTick + tickSpacing, maxTick - tickSpacing, 0, []);
+      await pool.burn(minTick, maxTick, 0, '0x');
+      await pool.burn(minTick + tickSpacing, maxTick - tickSpacing, 0, '0x');
 
       const { fees0: fees0Position0 } = await pool.positions(
         await getPositionKey(wallet.address, minTick, maxTick, pool)
@@ -1216,7 +1225,7 @@ describe('AlgebraPool', () => {
 
       await swapExact1For0(expandTo18Decimals(1), wallet.address);
 
-      await pool.burn(minTick, maxTick, 0, []);
+      await pool.burn(minTick, maxTick, 0, '0x');
 
       const { fees0: fees0Position0before, fees1: fees0Position1before } = await pool.positions(
         await getPositionKey(wallet.address, minTick, maxTick, pool)
@@ -1243,7 +1252,7 @@ describe('AlgebraPool', () => {
 
       await swapExact1For0(expandTo18Decimals(1), wallet.address);
 
-      await pool.burn(minTick, maxTick, 0, []);
+      await pool.burn(minTick, maxTick, 0, '0x');
 
       await expect(pool.collect(wallet.address, minTick, maxTick, 1000, 1000)).to.emit(pool, 'Collect')
       .withArgs(wallet.address, wallet.address, minTick, maxTick, 1000, 1000 );
@@ -1263,8 +1272,8 @@ describe('AlgebraPool', () => {
 
       await pool.setTickSpacing(200);
       // poke positions
-      await pool.burn(minTick, maxTick, 0, []);
-      await pool.burn(minTick + tickSpacing, maxTick - tickSpacing, 0, []);
+      await pool.burn(minTick, maxTick, 0, '0x');
+      await pool.burn(minTick + tickSpacing, maxTick - tickSpacing, 0, '0x');
 
       const { fees0: fees0Position0 } = await pool.positions(
         await getPositionKey(wallet.address, minTick, maxTick, pool)
@@ -1286,8 +1295,8 @@ describe('AlgebraPool', () => {
       await swapExact0For1(expandTo18Decimals(1), wallet.address);
 
       // poke positions
-      await pool.burn(minTick, maxTick, 0, []);
-      await pool.burn(minTick + tickSpacing, maxTick - tickSpacing, 0, []);
+      await pool.burn(minTick, maxTick, 0, '0x');
+      await pool.burn(minTick + tickSpacing, maxTick - tickSpacing, 0, '0x');
 
       const { fees0: fees0Position0 } = await pool.positions(
         await getPositionKey(wallet.address, minTick, maxTick, pool)
@@ -1305,7 +1314,7 @@ describe('AlgebraPool', () => {
       await mint(wallet.address, minTick, maxTick, expandTo18Decimals(1));
       await pool.setFee(0);
       await swap0ForExact1(expandTo18Decimals(1), other.address)
-      await pool.burn(minTick, maxTick, 0, []);
+      await pool.burn(minTick, maxTick, 0, '0x');
       const { fees0: fee0, fees1: fee1 } = await pool.positions(
         await getPositionKey(wallet.address, minTick, maxTick, pool)
       )
@@ -1319,12 +1328,12 @@ describe('AlgebraPool', () => {
       await mint(wallet.address, minTick, maxTick, amount);
       await pool.setFee(65535);
       await swapExact1For0(amount, other.address)
-      await pool.burn(minTick, maxTick, 0, []);
+      await pool.burn(minTick, maxTick, 0, '0x');
       const { fees0: fee0, fees1: fee1 } = await pool.positions(
         await getPositionKey(wallet.address, minTick, maxTick, pool)
       )
       expect(fee0).to.be.eq(0);
-      expect(fee1).to.be.eq(amount.mul(65535).div(1000000).sub(1));
+      expect(fee1).to.be.eq(amount * 65535n / 1000000n- 1n);
     });
 
     describe('works across large increases', () => {
@@ -1334,21 +1343,21 @@ describe('AlgebraPool', () => {
 
       // type(uint128).max * 2**128 / 1e18
       // https://www.wolframalpha.com/input/?i=%282**128+-+1%29+*+2**128+%2F+1e18
-      const magicNumber = BigNumber.from('115792089237316195423570985008687907852929702298719625575994');
+      const magicNumber = BigInt('115792089237316195423570985008687907852929702298719625575994');
 
       it('works just before the cap binds', async () => {
         await pool.setTotalFeeGrowth0Token(magicNumber);
-        await pool.burn(minTick, maxTick, 0, []);
+        await pool.burn(minTick, maxTick, 0, '0x');
 
         const { fees0, fees1 } = await pool.positions(await getPositionKey(wallet.address, minTick, maxTick, pool));
 
-        expect(fees0).to.be.eq(MaxUint128.sub(1));
+        expect(fees0).to.be.eq(MaxUint128- 1n);
         expect(fees1).to.be.eq(0);
       });
 
       it('works just after the cap binds', async () => {
-        await pool.setTotalFeeGrowth0Token(magicNumber.add(1));
-        await pool.burn(minTick, maxTick, 0, []);
+        await pool.setTotalFeeGrowth0Token(magicNumber + 1n);
+        await pool.burn(minTick, maxTick, 0, '0x');
 
         const { fees0, fees1 } = await pool.positions(await getPositionKey(wallet.address, minTick, maxTick, pool));
 
@@ -1357,8 +1366,8 @@ describe('AlgebraPool', () => {
       });
 
       it('works well after the cap binds', async () => {
-        await pool.setTotalFeeGrowth0Token(constants.MaxUint256);
-        await pool.burn(minTick, maxTick, 0, []);
+        await pool.setTotalFeeGrowth0Token(MaxUint256);
+        await pool.burn(minTick, maxTick, 0, '0x');
 
         const { fees0, fees1 } = await pool.positions(await getPositionKey(wallet.address, minTick, maxTick, pool));
 
@@ -1369,15 +1378,15 @@ describe('AlgebraPool', () => {
 
     describe('works across overflow boundaries', () => {
       beforeEach(async () => {
-        await pool.setTotalFeeGrowth0Token(constants.MaxUint256);
-        await pool.setTotalFeeGrowth1Token(constants.MaxUint256);
+        await pool.setTotalFeeGrowth0Token(MaxUint256);
+        await pool.setTotalFeeGrowth1Token(MaxUint256);
         await mint(wallet.address, minTick, maxTick, expandTo18Decimals(10));
       });
 
       it('token0', async () => {
         await swapExact0For1(expandTo18Decimals(1), wallet.address);
-        await pool.burn(minTick, maxTick, 0, []);
-        const { amount0, amount1 } = await pool.callStatic.collect(
+        await pool.burn(minTick, maxTick, 0, '0x');
+        const { amount0, amount1 } = await pool.collect.staticCall(
           wallet.address,
           minTick,
           maxTick,
@@ -1389,10 +1398,10 @@ describe('AlgebraPool', () => {
       });
 
       it('unexpected donation', async () => {
-        await token1.transfer(pool.address, expandTo18Decimals(1));
-        await token0.transfer(pool.address, expandTo18Decimals(2));
-        await pool.burn(minTick, maxTick, 0, []);
-        const { amount0, amount1 } = await pool.callStatic.collect(
+        await token1.transfer(pool, expandTo18Decimals(1));
+        await token0.transfer(pool, expandTo18Decimals(2));
+        await pool.burn(minTick, maxTick, 0, '0x');
+        const { amount0, amount1 } = await pool.collect.staticCall(
           wallet.address,
           minTick,
           maxTick,
@@ -1404,9 +1413,9 @@ describe('AlgebraPool', () => {
       });
       it('token0 with unexpected donation before burn', async () => {
         await swapExact0For1(expandTo18Decimals(1), wallet.address);
-        await token0.transfer(pool.address, expandTo18Decimals(1));
-        await pool.burn(minTick, maxTick, 0, []);
-        const { amount0, amount1 } = await pool.callStatic.collect(
+        await token0.transfer(pool, expandTo18Decimals(1));
+        await pool.burn(minTick, maxTick, 0, '0x');
+        const { amount0, amount1 } = await pool.collect.staticCall(
           wallet.address,
           minTick,
           maxTick,
@@ -1417,10 +1426,10 @@ describe('AlgebraPool', () => {
         expect(amount1).to.be.eq(0);
       });
       it('token0 with unexpected donation before swap', async () => {
-        await token0.transfer(pool.address, expandTo18Decimals(1));
+        await token0.transfer(pool, expandTo18Decimals(1));
         await swapExact0For1(expandTo18Decimals(1), wallet.address);
-        await pool.burn(minTick, maxTick, 0, []);
-        const { amount0, amount1 } = await pool.callStatic.collect(
+        await pool.burn(minTick, maxTick, 0, '0x');
+        const { amount0, amount1 } = await pool.collect.staticCall(
           wallet.address,
           minTick,
           maxTick,
@@ -1432,8 +1441,8 @@ describe('AlgebraPool', () => {
       });
       it('token1', async () => {
         await swapExact1For0(expandTo18Decimals(1), wallet.address);
-        await pool.burn(minTick, maxTick, 0, []);
-        const { amount0, amount1 } = await pool.callStatic.collect(
+        await pool.burn(minTick, maxTick, 0, '0x');
+        const { amount0, amount1 } = await pool.collect.staticCall(
           wallet.address,
           minTick,
           maxTick,
@@ -1445,9 +1454,9 @@ describe('AlgebraPool', () => {
       });
       it('token1 with unexpected donation before burn', async () => {
         await swapExact1For0(expandTo18Decimals(1), wallet.address);
-        await token1.transfer(pool.address, expandTo18Decimals(1));
-        await pool.burn(minTick, maxTick, 0, []);
-        const { amount0, amount1 } = await pool.callStatic.collect(
+        await token1.transfer(pool, expandTo18Decimals(1));
+        await pool.burn(minTick, maxTick, 0, '0x');
+        const { amount0, amount1 } = await pool.collect.staticCall(
           wallet.address,
           minTick,
           maxTick,
@@ -1458,10 +1467,10 @@ describe('AlgebraPool', () => {
         expect(amount1).to.be.eq('1000099999999999999');
       });
       it('token1 with unexpected donation before swap', async () => {
-        await token1.transfer(pool.address, expandTo18Decimals(1));
+        await token1.transfer(pool, expandTo18Decimals(1));
         await swapExact1For0(expandTo18Decimals(1), wallet.address);
-        await pool.burn(minTick, maxTick, 0, []);
-        const { amount0, amount1 } = await pool.callStatic.collect(
+        await pool.burn(minTick, maxTick, 0, '0x');
+        const { amount0, amount1 } = await pool.collect.staticCall(
           wallet.address,
           minTick,
           maxTick,
@@ -1474,8 +1483,8 @@ describe('AlgebraPool', () => {
       it('token0 and token1', async () => {
         await swapExact0For1(expandTo18Decimals(1), wallet.address);
         await swapExact1For0(expandTo18Decimals(1), wallet.address);
-        await pool.burn(minTick, maxTick, 0, []);
-        const { amount0, amount1 } = await pool.callStatic.collect(
+        await pool.burn(minTick, maxTick, 0, '0x');
+        const { amount0, amount1 } = await pool.collect.staticCall(
           wallet.address,
           minTick,
           maxTick,
@@ -1488,10 +1497,10 @@ describe('AlgebraPool', () => {
       it('token0 and token1 with unexpected donation before burn', async () => {
         await swapExact0For1(expandTo18Decimals(1), wallet.address);
         await swapExact1For0(expandTo18Decimals(1), wallet.address);
-        await token1.transfer(pool.address, expandTo18Decimals(1));
-        await token0.transfer(pool.address, expandTo18Decimals(2));
-        await pool.burn(minTick, maxTick, 0, []);
-        const { amount0, amount1 } = await pool.callStatic.collect(
+        await token1.transfer(pool, expandTo18Decimals(1));
+        await token0.transfer(pool, expandTo18Decimals(2));
+        await pool.burn(minTick, maxTick, 0, '0x');
+        const { amount0, amount1 } = await pool.collect.staticCall(
           wallet.address,
           minTick,
           maxTick,
@@ -1502,12 +1511,12 @@ describe('AlgebraPool', () => {
         expect(amount1).to.be.eq('1000099999999999999');
       });
       it('token0 and token1 with unexpected donation before swaps', async () => {
-        await token1.transfer(pool.address, expandTo18Decimals(1));
-        await token0.transfer(pool.address, expandTo18Decimals(2));
+        await token1.transfer(pool, expandTo18Decimals(1));
+        await token0.transfer(pool, expandTo18Decimals(2));
         await swapExact0For1(expandTo18Decimals(1), wallet.address);
         await swapExact1For0(expandTo18Decimals(1), wallet.address);
-        await pool.burn(minTick, maxTick, 0, []);
-        const { amount0, amount1 } = await pool.callStatic.collect(
+        await pool.burn(minTick, maxTick, 0, '0x');
+        const { amount0, amount1 } = await pool.collect.staticCall(
           wallet.address,
           minTick,
           maxTick,
@@ -1552,7 +1561,7 @@ describe('AlgebraPool', () => {
       poke,
       supportingFee,
     }: {
-      amount: BigNumberish;
+      amount: bigint;
       zeroToOne: boolean;
       poke: boolean;
       supportingFee?: boolean;
@@ -1565,9 +1574,9 @@ describe('AlgebraPool', () => {
         await (zeroToOne ? swapExact0For1(amount, wallet.address) : swapExact1For0(amount, wallet.address));
       }
 
-      if (poke) await pool.burn(minTick, maxTick, 0, []);
+      if (poke) await pool.burn(minTick, maxTick, 0, '0x');
 
-      const { amount0: fees0, amount1: fees1 } = await pool.callStatic.collect(
+      const { amount0: fees0, amount1: fees1 } = await pool.collect.staticCall(
         wallet.address,
         minTick,
         maxTick,
@@ -1841,10 +1850,10 @@ describe('AlgebraPool', () => {
       expect(communityFeePending0).to.be.eq('17000000000000');
       expect(Number((await token1.balanceOf(vaultAddress)).toString())).to.eq(0);
 
-      await pool.burn(minTick, maxTick, 0, []); // poke to update fees
+      await pool.burn(minTick, maxTick, 0, '0x'); // poke to update fees
       await expect(pool.collect(wallet.address, minTick, maxTick, MaxUint128, MaxUint128))
         .to.emit(token0, 'Transfer')
-        .withArgs(pool.address, wallet.address, '82999999999999');
+        .withArgs(await pool.getAddress(), wallet.address, '82999999999999');
       expect((await token0.balanceOf(vaultAddress)).toString()).to.eq('17000000000000');
 
       const [communityFeePending0After] = await pool.getCommunityFeePending();
@@ -1904,10 +1913,10 @@ describe('AlgebraPool', () => {
         await mint(wallet.address, -260, -130, 1);
       });
       it('swapping across gaps works in 1 for 0 direction', async () => {
-        const liquidityAmount = expandTo18Decimals(1).div(4);
+        const liquidityAmount = expandTo18Decimals(1) / 4n;
         await mint(wallet.address, 120000, 121200, liquidityAmount);
         await swapExact1For0(expandTo18Decimals(1), wallet.address);
-        await expect(pool.burn(120000, 121200, liquidityAmount, []))
+        await expect(pool.burn(120000, 121200, liquidityAmount, '0x'))
           .to.emit(pool, 'Burn')
           .withArgs(wallet.address, 120000, 121200, liquidityAmount, '30009977315155', '999899999999999999')
           .to.not.emit(token0, 'Transfer')
@@ -1915,10 +1924,10 @@ describe('AlgebraPool', () => {
         expect((await pool.globalState()).tick).to.eq(120197);
       });
       it('swapping across gaps works in 0 for 1 direction', async () => {
-        const liquidityAmount = expandTo18Decimals(1).div(4);
+        const liquidityAmount = expandTo18Decimals(1) / 4n;
         await mint(wallet.address, -121200, -120000, liquidityAmount);
         await swapExact0For1(expandTo18Decimals(1), wallet.address);
-        await expect(pool.burn(-121200, -120000, liquidityAmount, []))
+        await expect(pool.burn(-121200, -120000, liquidityAmount, '0x'))
           .to.emit(pool, 'Burn')
           .withArgs(wallet.address, -121200, -120000, liquidityAmount, '999899999999999999', '30009977315155')
           .to.not.emit(token0, 'Transfer')
@@ -1943,7 +1952,7 @@ describe('AlgebraPool', () => {
     const PriceMovementMath = (await (
       await ethers.getContractFactory('PriceMovementMathTest')
     ).deploy()) as PriceMovementMathTest;
-    const p0 = (await sqrtTickMath.getSqrtRatioAtTick(-24081)).add(1);
+    const p0 = (await sqrtTickMath.getSqrtRatioAtTick(-24081)) + 1n;
     // initialize at a price of ~0.3 token1/token0
     // meaning if you swap in 2 token0, you should end up getting 0 token1
     await pool.initialize(p0);
@@ -1963,12 +1972,12 @@ describe('AlgebraPool', () => {
     {
       const { feeAmount, amountIn, amountOut, sqrtQ } = await PriceMovementMath.movePriceTowardsTarget(
         p0,
-        p0.sub(1),
+        p0- 1n,
         liquidity,
         3,
         FeeAmount.MEDIUM
       );
-      expect(sqrtQ, 'price moves').to.eq(p0.sub(1));
+      expect(sqrtQ, 'price moves').to.eq(p0- 1n);
       expect(feeAmount, 'fee amount is 1').to.eq(1);
       expect(amountIn, 'amount in is 1').to.eq(1);
       expect(amountOut, 'zero amount out').to.eq(0);
@@ -1977,14 +1986,14 @@ describe('AlgebraPool', () => {
     // swap 2 amount in, should get 0 amount out
     await expect(swapExact0For1(3, wallet.address))
       .to.emit(token0, 'Transfer')
-      .withArgs(wallet.address, pool.address, 3)
+      .withArgs(wallet.address, await pool.getAddress(), 3)
       .to.not.emit(token1, 'Transfer');
 
     const { tick, price } = await pool.globalState();
 
     expect(tick, 'pool is at the next tick').to.eq(-24082);
-    expect(price, 'pool price is still on the p0 boundary').to.eq(p0.sub(1));
-    expect(await pool.liquidity(), 'pool has run tick transition and liquidity changed').to.eq(liquidity.mul(2));
+    expect(price, 'pool price is still on the p0 boundary').to.eq(p0- 1n);
+    expect(await pool.liquidity(), 'pool has run tick transition and liquidity changed').to.eq(liquidity * 2n);
   });
 
   describe('#fee getter', async () => {
@@ -1995,8 +2004,8 @@ describe('AlgebraPool', () => {
 
     it('works with plugin', async () => {
       const MockPoolPluginFactory = await ethers.getContractFactory('MockPoolPlugin');
-      const poolPlugin = (await MockPoolPluginFactory.deploy(pool.address)) as MockPoolPlugin;
-      await pool.setPlugin(poolPlugin.address);
+      const poolPlugin = (await MockPoolPluginFactory.deploy(await pool.getAddress())) as MockPoolPlugin;
+      await pool.setPlugin(poolPlugin);
       await pool.setPluginConfig(255);
 
       expect(await pool.fee()).to.be.eq(220);
@@ -2019,19 +2028,19 @@ describe('AlgebraPool', () => {
       await pool.initialize(encodePriceSqrt(1, 1));
       const tickSpacing = await pool.tickSpacing();
       await mint(wallet.address, -tickSpacing, tickSpacing, initializeLiquidityAmount);
-      await swapExact0For1(initializeLiquidityAmount.mul(10000), wallet.address);
+      await swapExact0For1(initializeLiquidityAmount * 10000n, wallet.address);
       expect(await pool.liquidity()).to.be.eq(0);
-      await expect(flash(100, 0, other.address)).to.emit(token0, 'Transfer').withArgs(pool.address, other.address, 100);
+      await expect(flash(100, 0, other.address)).to.emit(token0, 'Transfer').withArgs(await pool.getAddress(), other.address, 100);
       await expect(flash(100, 100, other.address)).to.be.revertedWithCustomError(pool, 'transferFailed');
     });
 
     it('flash overflows communityFee0', async () => {
       await pool.initialize(encodePriceSqrt(1, 1));
       await pool.setCommunityFee(1000);
-      const MAX_PENDING_FEE = BigNumber.from(2).pow(104).sub(1);
+      const MAX_PENDING_FEE = 2n**104n- 1n;
 
-      await token0.approve(swapTarget.address, constants.MaxUint256);
-      await token1.approve(swapTarget.address, constants.MaxUint256);
+      await token0.approve(swapTarget, MaxUint256);
+      await token1.approve(swapTarget, MaxUint256);
 
       await flash(0, 0, wallet.address, 1, 1);
       await flash(0, 0, wallet.address, MAX_PENDING_FEE, 0);
@@ -2045,10 +2054,10 @@ describe('AlgebraPool', () => {
     it('flash overflows communityFee1', async () => {
       await pool.initialize(encodePriceSqrt(1, 1));
       await pool.setCommunityFee(1000);
-      const MAX_PENDING_FEE = BigNumber.from(2).pow(104).sub(1);
+      const MAX_PENDING_FEE = 2n**104n- 1n;
 
-      await token0.approve(swapTarget.address, constants.MaxUint256);
-      await token1.approve(swapTarget.address, constants.MaxUint256);
+      await token0.approve(swapTarget, MaxUint256);
+      await token1.approve(swapTarget, MaxUint256);
 
       await flash(0, 0, wallet.address, 1, 1);
       await flash(0, 0, wallet.address, 0, MAX_PENDING_FEE);
@@ -2060,13 +2069,13 @@ describe('AlgebraPool', () => {
     });
 
     describe('after liquidity added', () => {
-      let balanceToken0: BigNumber;
-      let balanceToken1: BigNumber;
+      let balanceToken0: bigint;
+      let balanceToken1: bigint;
       beforeEach('add some tokens', async () => {
         await initializeAtZeroTick(pool);
         [balanceToken0, balanceToken1] = await Promise.all([
-          token0.balanceOf(pool.address),
-          token1.balanceOf(pool.address),
+          token0.balanceOf(pool),
+          token1.balanceOf(pool),
         ]);
       });
 
@@ -2074,50 +2083,50 @@ describe('AlgebraPool', () => {
         it('emits an event', async () => {
           await expect(flash(1001, 2001, other.address))
             .to.emit(pool, 'Flash')
-            .withArgs(swapTarget.address, other.address, 1001, 2001, 1, 1);
+            .withArgs(await swapTarget.getAddress(), other.address, 1001, 2001, 1, 1);
         });
 
         it('emits an event', async () => {
           await expect(flash(1, 1, other.address))
             .to.emit(pool, 'Flash')
-            .withArgs(swapTarget.address, other.address, 1, 1, 1, 1);
+            .withArgs(await swapTarget.getAddress(), other.address, 1, 1, 1, 1);
         });
 
         it('transfers the amount0 to the recipient', async () => {
           await expect(flash(100, 200, other.address))
             .to.emit(token0, 'Transfer')
-            .withArgs(pool.address, other.address, 100);
+            .withArgs(await pool.getAddress(), other.address, 100);
         });
         it('transfers the amount1 to the recipient', async () => {
           await expect(flash(100, 200, other.address))
             .to.emit(token1, 'Transfer')
-            .withArgs(pool.address, other.address, 200);
+            .withArgs(await pool.getAddress(), other.address, 200);
         });
         it('can flash only token0', async () => {
           await expect(flash(101, 0, other.address))
             .to.emit(token0, 'Transfer')
-            .withArgs(pool.address, other.address, 101)
+            .withArgs(await pool.getAddress(), other.address, 101)
             .to.not.emit(token1, 'Transfer');
         });
         it('can flash only token1', async () => {
           await expect(flash(0, 102, other.address))
             .to.emit(token1, 'Transfer')
-            .withArgs(pool.address, other.address, 102)
+            .withArgs(await pool.getAddress(), other.address, 102)
             .to.not.emit(token0, 'Transfer');
         });
         it('can flash entire token balance', async () => {
           await expect(flash(balanceToken0, balanceToken1, other.address))
             .to.emit(token0, 'Transfer')
-            .withArgs(pool.address, other.address, balanceToken0)
+            .withArgs(await pool.getAddress(), other.address, balanceToken0)
             .to.emit(token1, 'Transfer')
-            .withArgs(pool.address, other.address, balanceToken1);
+            .withArgs(await pool.getAddress(), other.address, balanceToken1);
         });
         it('no-op if both amounts are 0', async () => {
           await expect(flash(0, 0, other.address)).to.not.emit(token0, 'Transfer').to.not.emit(token1, 'Transfer');
         });
         it('fails if flash amount is greater than token balance', async () => {
-          await expect(flash(balanceToken0.add(1), balanceToken1, other.address)).to.be.reverted;
-          await expect(flash(balanceToken0, balanceToken1.add(1), other.address)).to.be.reverted;
+          await expect(flash(balanceToken0 + 1n, balanceToken1, other.address)).to.be.reverted;
+          await expect(flash(balanceToken0, balanceToken1 + 1n, other.address)).to.be.reverted;
         });
         it('calls the flash callback on the sender with correct fee amounts', async () => {
           await expect(flash(1001, 2002, other.address)).to.emit(swapTarget, 'FlashCallback').withArgs(1, 1);
@@ -2127,51 +2136,51 @@ describe('AlgebraPool', () => {
           expect(await pool.totalFeeGrowth0Token()).to.eq(0);
           expect(await pool.totalFeeGrowth1Token()).to.eq(0);
 
-          await pool.burn(minTick, maxTick, 0, []);
+          await pool.burn(minTick, maxTick, 0, '0x');
           expect(await pool.totalFeeGrowth0Token()).to.eq(
-            BigNumber.from(1).mul(BigNumber.from(2).pow(128)).div(expandTo18Decimals(2))
+            (2n ** 128n) / expandTo18Decimals(2)
           );
           expect(await pool.totalFeeGrowth1Token()).to.eq(
-            BigNumber.from(1).mul(BigNumber.from(2).pow(128)).div(expandTo18Decimals(2))
+            (2n ** 128n) / expandTo18Decimals(2)
           );
         });
         it('increases the fee growth by the expected amount after unexpected donation of token0', async () => {
-          await token0.transfer(pool.address, expandTo18Decimals(2));
+          await token0.transfer(pool, expandTo18Decimals(2));
           await flash(1001, 2002, other.address);
           expect(await pool.totalFeeGrowth1Token()).to.eq(0);
 
-          await pool.burn(minTick, maxTick, 0, []);
+          await pool.burn(minTick, maxTick, 0, '0x');
           expect(await pool.totalFeeGrowth0Token()).to.eq(
-            BigNumber.from(expandTo18Decimals(2).add(1)).mul(BigNumber.from(2).pow(128)).div(expandTo18Decimals(2))
+            (expandTo18Decimals(2) + 1n) * (2n ** 128n) / expandTo18Decimals(2)
           );
           expect(await pool.totalFeeGrowth1Token()).to.eq(
-            BigNumber.from(1).mul(BigNumber.from(2).pow(128)).div(expandTo18Decimals(2))
+            (2n ** 128n) / expandTo18Decimals(2)
           );
         });
         it('increases the fee growth by the expected amount after unexpected donation of token1', async () => {
-          await token1.transfer(pool.address, expandTo18Decimals(1));
+          await token1.transfer(pool, expandTo18Decimals(1));
           await flash(1001, 2002, other.address);
           expect(await pool.totalFeeGrowth0Token()).to.eq(0);
 
-          await pool.burn(minTick, maxTick, 0, []);
+          await pool.burn(minTick, maxTick, 0, '0x');
           expect(await pool.totalFeeGrowth0Token()).to.eq(
-            BigNumber.from(1).mul(BigNumber.from(2).pow(128)).div(expandTo18Decimals(2))
+            (2n ** 128n) / expandTo18Decimals(2)
           );
           expect(await pool.totalFeeGrowth1Token()).to.eq(
-            BigNumber.from(expandTo18Decimals(1).add(1)).mul(BigNumber.from(2).pow(128)).div(expandTo18Decimals(2))
+            (expandTo18Decimals(1) + 1n) * (2n ** 128n) / expandTo18Decimals(2)
           );
         });
         it('increases the fee growth by the expected amount after unexpected donation', async () => {
-          await token0.transfer(pool.address, expandTo18Decimals(2));
-          await token1.transfer(pool.address, expandTo18Decimals(1));
+          await token0.transfer(pool, expandTo18Decimals(2));
+          await token1.transfer(pool, expandTo18Decimals(1));
           await flash(1001, 2002, other.address);
 
-          await pool.burn(minTick, maxTick, 0, []);
+          await pool.burn(minTick, maxTick, 0, '0x');
           expect(await pool.totalFeeGrowth0Token()).to.eq(
-            BigNumber.from(expandTo18Decimals(2).add(1)).mul(BigNumber.from(2).pow(128)).div(expandTo18Decimals(2))
+            (expandTo18Decimals(2) + 1n) * (2n ** 128n) / expandTo18Decimals(2)
           );
           expect(await pool.totalFeeGrowth1Token()).to.eq(
-            BigNumber.from(expandTo18Decimals(1).add(1)).mul(BigNumber.from(2).pow(128)).div(expandTo18Decimals(2))
+            (expandTo18Decimals(1) + 1n) * (2n ** 128n) / expandTo18Decimals(2)
           );
         });
         it('fails if original balance not returned in either token', async () => {
@@ -2183,39 +2192,39 @@ describe('AlgebraPool', () => {
           await expect(flash(0, 1000, other.address, 0, 1000)).to.be.reverted;
         });
         it('allows donating token0', async () => {
-          await expect(flash(0, 0, constants.AddressZero, 567, 0))
+          await expect(flash(0, 0, ZeroAddress, 567, 0))
             .to.emit(token0, 'Transfer')
-            .withArgs(wallet.address, pool.address, 567)
+            .withArgs(wallet.address, await pool.getAddress(), 567)
             .to.not.emit(token1, 'Transfer');
-          await pool.burn(minTick, maxTick, 0, []);
+          await pool.burn(minTick, maxTick, 0, '0x');
           expect(await pool.totalFeeGrowth0Token()).to.eq(
-            BigNumber.from(567).mul(BigNumber.from(2).pow(128)).div(expandTo18Decimals(2))
+            567n * (2n ** 128n) / expandTo18Decimals(2)
           );
         });
         it('allows donating token1', async () => {
-          await expect(flash(0, 0, constants.AddressZero, 0, 678))
+          await expect(flash(0, 0, ZeroAddress, 0, 678))
             .to.emit(token1, 'Transfer')
-            .withArgs(wallet.address, pool.address, 678)
+            .withArgs(wallet.address, await pool.getAddress(), 678)
             .to.not.emit(token0, 'Transfer');
-          await pool.burn(minTick, maxTick, 0, []);
+          await pool.burn(minTick, maxTick, 0, '0x');
           expect(await pool.totalFeeGrowth1Token()).to.eq(
-            BigNumber.from(678).mul(BigNumber.from(2).pow(128)).div(expandTo18Decimals(2))
+            678n * (2n ** 128n) / expandTo18Decimals(2)
           );
         });
         it('allows donating token0 and token1 together', async () => {
-          await expect(flash(0, 0, constants.AddressZero, 789, 1234))
+          await expect(flash(0, 0, ZeroAddress, 789, 1234))
             .to.emit(token0, 'Transfer')
-            .withArgs(wallet.address, pool.address, 789)
+            .withArgs(wallet.address, await pool.getAddress(), 789)
             .to.emit(token1, 'Transfer')
-            .withArgs(wallet.address, pool.address, 1234);
+            .withArgs(wallet.address, await pool.getAddress(), 1234);
 
-          await pool.burn(minTick, maxTick, 0, []);
+          await pool.burn(minTick, maxTick, 0, '0x');
 
           expect(await pool.totalFeeGrowth0Token()).to.eq(
-            BigNumber.from(789).mul(BigNumber.from(2).pow(128)).div(expandTo18Decimals(2))
+            789n * (2n ** 128n) / expandTo18Decimals(2)
           );
           expect(await pool.totalFeeGrowth1Token()).to.eq(
-            BigNumber.from(1234).mul(BigNumber.from(2).pow(128)).div(expandTo18Decimals(2))
+            1234n * (2n ** 128n) / expandTo18Decimals(2)
           );
         });
       });
@@ -2228,7 +2237,7 @@ describe('AlgebraPool', () => {
         it('emits an event', async () => {
           await expect(flash(1001, 2001, other.address))
             .to.emit(pool, 'Flash')
-            .withArgs(swapTarget.address, other.address, 1001, 2001, 1, 1);
+            .withArgs(await swapTarget.getAddress(), other.address, 1001, 2001, 1, 1);
         });
 
         it('increases the fee growth by the expected amount', async () => {
@@ -2236,58 +2245,54 @@ describe('AlgebraPool', () => {
           expect(await pool.totalFeeGrowth0Token()).to.eq(0);
           expect(await pool.totalFeeGrowth1Token()).to.eq(0);
 
-          await pool.burn(minTick, maxTick, 0, []);
+          await pool.burn(minTick, maxTick, 0, '0x');
 
-          expect(await pool.totalFeeGrowth0Token()).to.eq(
-            BigNumber.from(3).mul(BigNumber.from(2).pow(128)).div(expandTo18Decimals(2))
-          );
-          expect(await pool.totalFeeGrowth1Token()).to.eq(
-            BigNumber.from(8).mul(BigNumber.from(2).pow(128)).div(expandTo18Decimals(2))
-          );
+          expect(await pool.totalFeeGrowth0Token()).to.eq(3n * (2n ** 128n) / expandTo18Decimals(2));
+          expect(await pool.totalFeeGrowth1Token()).to.eq(8n * (2n ** 128n) / expandTo18Decimals(2));
 
           expect(Number((await token0.balanceOf(vaultAddress)).toString())).to.eq(0);
           expect(Number((await token1.balanceOf(vaultAddress)).toString())).to.eq(1);
         });
         it('allows donating token0', async () => {
-          await expect(flash(0, 0, constants.AddressZero, 567, 0))
+          await expect(flash(0, 0, ZeroAddress, 567, 0))
             .to.emit(token0, 'Transfer')
-            .withArgs(wallet.address, pool.address, 567)
+            .withArgs(wallet.address, await pool.getAddress(), 567)
             .to.not.emit(token1, 'Transfer');
 
-          await pool.burn(minTick, maxTick, 0, []);
+          await pool.burn(minTick, maxTick, 0, '0x');
 
           const [communityFeePending0] = await pool.getCommunityFeePending();
           expect(Number(communityFeePending0.toString())).to.eq(0);
           expect(Number((await token0.balanceOf(vaultAddress)).toString())).to.eq(96);
 
           expect(await pool.totalFeeGrowth0Token()).to.eq(
-            BigNumber.from(471).mul(BigNumber.from(2).pow(128)).div(expandTo18Decimals(2))
+            471n * (2n ** 128n) / expandTo18Decimals(2)
           );
         });
         it('allows donating token1', async () => {
-          await expect(flash(0, 0, constants.AddressZero, 0, 678))
+          await expect(flash(0, 0, ZeroAddress, 0, 678))
             .to.emit(token1, 'Transfer')
-            .withArgs(wallet.address, pool.address, 678)
+            .withArgs(wallet.address, await pool.getAddress(), 678)
             .to.not.emit(token0, 'Transfer');
 
-          await pool.burn(minTick, maxTick, 0, []);
+          await pool.burn(minTick, maxTick, 0, '0x');
 
           const [, communityFeePending1] = await pool.getCommunityFeePending();
           expect(Number(communityFeePending1.toString())).to.eq(0);
           expect(Number((await token1.balanceOf(vaultAddress)).toString())).to.eq(115);
 
           expect(await pool.totalFeeGrowth1Token()).to.eq(
-            BigNumber.from(563).mul(BigNumber.from(2).pow(128)).div(expandTo18Decimals(2))
+            563n * (2n ** 128n) / expandTo18Decimals(2)
           );
         });
         it('allows donating token0 and token1 together', async () => {
-          await expect(flash(0, 0, constants.AddressZero, 789, 1234))
+          await expect(flash(0, 0, ZeroAddress, 789, 1234))
             .to.emit(token0, 'Transfer')
-            .withArgs(wallet.address, pool.address, 789)
+            .withArgs(wallet.address, await pool.getAddress(), 789)
             .to.emit(token1, 'Transfer')
-            .withArgs(wallet.address, pool.address, 1234);
+            .withArgs(wallet.address, await pool.getAddress(), 1234);
 
-          await pool.burn(minTick, maxTick, 0, []);
+          await pool.burn(minTick, maxTick, 0, '0x');
 
           const [communityFeePending0, communityFeePending1] = await pool.getCommunityFeePending();
           expect(Number(communityFeePending0.toString())).to.eq(0);
@@ -2297,10 +2302,10 @@ describe('AlgebraPool', () => {
           expect(Number((await token1.balanceOf(vaultAddress)).toString())).to.eq(209);
 
           expect(await pool.totalFeeGrowth0Token()).to.eq(
-            BigNumber.from(655).mul(BigNumber.from(2).pow(128)).div(expandTo18Decimals(2))
+            655n * (2n ** 128n) / expandTo18Decimals(2)
           );
           expect(await pool.totalFeeGrowth1Token()).to.eq(
-            BigNumber.from(1025).mul(BigNumber.from(2).pow(128)).div(expandTo18Decimals(2))
+            1025n * (2n ** 128n) / expandTo18Decimals(2)
           );
         });
       });
@@ -2386,8 +2391,8 @@ describe('AlgebraPool', () => {
       let callbackData: string
       beforeEach('create plugin', async () => {
         const MockPoolPluginFactory = await ethers.getContractFactory('MockPoolPlugin');
-        poolPlugin = (await MockPoolPluginFactory.deploy(pool.address)) as MockPoolPlugin;
-        await pool.setPlugin(poolPlugin.address);
+        poolPlugin = (await MockPoolPluginFactory.deploy(pool)) as MockPoolPlugin;
+        await pool.setPlugin(poolPlugin);
         await pool.setPluginConfig(255);
         callbackData = encodeCallback(wallet.address)
       });
@@ -2408,20 +2413,20 @@ describe('AlgebraPool', () => {
         await pool.initialize(encodePriceSqrt(1, 1));
         await expect(mint(wallet.address, minTick, maxTick, expandTo18Decimals(1)))
           .to.be.emit(poolPlugin, 'BeforeModifyPosition')
-          .withArgs(swapTarget.address, wallet.address, minTick, maxTick, expandTo18Decimals(1), callbackData);
+          .withArgs(await swapTarget.getAddress(), wallet.address, minTick, maxTick, expandTo18Decimals(1), callbackData);
       });
 
       it('after mint the hook is called', async () => {
         await pool.initialize(encodePriceSqrt(1, 1));
         await expect(mint(wallet.address, minTick, maxTick, expandTo18Decimals(1)))
           .to.be.emit(poolPlugin, 'AfterModifyPosition')
-          .withArgs(swapTarget.address, wallet.address, minTick, maxTick, expandTo18Decimals(1), expandTo18Decimals(1), expandTo18Decimals(1), callbackData);
+          .withArgs(await swapTarget.getAddress(), wallet.address, minTick, maxTick, expandTo18Decimals(1), expandTo18Decimals(1), expandTo18Decimals(1), callbackData);
       });
 
       it('before burn the hook is called', async () => {
         await pool.initialize(encodePriceSqrt(1, 1));
         await mint(wallet.address, minTick, maxTick, expandTo18Decimals(1));
-        await expect(pool.burn(minTick, maxTick, expandTo18Decimals(1), []))
+        await expect(pool.burn(minTick, maxTick, expandTo18Decimals(1), '0x'))
           .to.be.emit(poolPlugin, 'BeforeModifyPosition')
           .withArgs(wallet.address, wallet.address, minTick, maxTick, expandTo18Decimals(-1), '0x');
       });
@@ -2429,9 +2434,9 @@ describe('AlgebraPool', () => {
       it('after burn the hook is called', async () => {
         await pool.initialize(encodePriceSqrt(1, 1));
         await mint(wallet.address, minTick, maxTick, expandTo18Decimals(1));
-        await expect(pool.burn(minTick, maxTick, expandTo18Decimals(1), []))
+        await expect(pool.burn(minTick, maxTick, expandTo18Decimals(1), '0x'))
           .to.be.emit(poolPlugin, 'AfterModifyPosition')
-          .withArgs(wallet.address, wallet.address, minTick, maxTick, expandTo18Decimals(-1), expandTo18Decimals(1).sub(1), expandTo18Decimals(1).sub(1), '0x');
+          .withArgs(wallet.address, wallet.address, minTick, maxTick, expandTo18Decimals(-1), expandTo18Decimals(1)- 1n, expandTo18Decimals(1)- 1n, '0x');
       });
 
       it('before swap fee on transfer tokens the hook is called', async () => {
@@ -2439,7 +2444,7 @@ describe('AlgebraPool', () => {
         await mint(wallet.address, minTick, maxTick, expandTo18Decimals(1));
         await expect(swapExact1For0SupportingFee(10000, wallet.address))
           .to.be.emit(poolPlugin, 'BeforeSwap')
-          .withArgs(swapTarget.address, wallet.address, false, 10000, MAX_SQRT_RATIO.sub(1), true, callbackData);
+          .withArgs(await swapTarget.getAddress(), wallet.address, false, 10000, MAX_SQRT_RATIO- 1n, true, callbackData);
       });
 
       it('after swap fee on transfer tokens the hook is called', async () => {
@@ -2447,7 +2452,7 @@ describe('AlgebraPool', () => {
         await mint(wallet.address, minTick, maxTick, expandTo18Decimals(1));
         await expect(swapExact1For0SupportingFee(10000, wallet.address))
           .to.be.emit(poolPlugin, 'AfterSwap')
-          .withArgs(swapTarget.address, wallet.address, false, 10000, MAX_SQRT_RATIO.sub(1), -9998, 10000, callbackData);
+          .withArgs(await swapTarget.getAddress(), wallet.address, false, 10000, MAX_SQRT_RATIO- 1n, -9998, 10000, callbackData);
       });
 
       it('before swap the hook is called', async () => {
@@ -2455,7 +2460,7 @@ describe('AlgebraPool', () => {
         await mint(wallet.address, minTick, maxTick, expandTo18Decimals(1));
         await expect(swapExact0For1(10000, wallet.address))
           .to.be.emit(poolPlugin, 'BeforeSwap')
-          .withArgs(swapTarget.address, wallet.address, true, 10000, MIN_SQRT_RATIO.add(1), false, callbackData);
+          .withArgs(await swapTarget.getAddress(), wallet.address, true, 10000, MIN_SQRT_RATIO + 1n, false, callbackData);
       });
 
       it('after swap the hook is called', async () => {
@@ -2463,50 +2468,50 @@ describe('AlgebraPool', () => {
         await mint(wallet.address, minTick, maxTick, expandTo18Decimals(1));
         await expect(swapExact0For1(10000, wallet.address))
           .to.be.emit(poolPlugin, 'AfterSwap')
-          .withArgs(swapTarget.address, wallet.address, true, 10000, MIN_SQRT_RATIO.add(1), 10000, -9998, callbackData);
+          .withArgs(await swapTarget.getAddress(), wallet.address, true, 10000, MIN_SQRT_RATIO + 1n, 10000, -9998, callbackData);
       });
 
       it('before flash the hook is called', async () => {
         await pool.initialize(encodePriceSqrt(1, 1));
         await mint(wallet.address, minTick, maxTick, expandTo18Decimals(1));
-        callbackData = encodeCallback(wallet.address, BigNumber.from(101), BigNumber.from(201))
+        callbackData = encodeCallback(wallet.address, 101n, 201n)
         await expect(flash(100, 200, other.address))
           .to.be.emit(poolPlugin, 'BeforeFlash')
-          .withArgs(swapTarget.address, other.address, 100, 200, callbackData);
+          .withArgs(await swapTarget.getAddress(), other.address, 100, 200, callbackData);
       });
 
       it('after flash the hook is called', async () => {
         await pool.initialize(encodePriceSqrt(1, 1));
         await mint(wallet.address, minTick, maxTick, expandTo18Decimals(1));
-        callbackData = encodeCallback(wallet.address, BigNumber.from(101), BigNumber.from(201))
+        callbackData = encodeCallback(wallet.address, 101n, 201n)
         await expect(flash(100, 200, other.address))
-          .to.be.emit(poolPlugin, 'AfterFlash')
-          .withArgs(swapTarget.address, other.address, 100, 200, 1, 1, callbackData);
+          .to.emit(poolPlugin, 'AfterFlash')
+          .withArgs(await swapTarget.getAddress(), other.address, 100, 200, 1, 1, callbackData);
       });
 
       it('transaction reverted if plugin returns incorrect selector for beforeInitialized hook', async () => {
         await poolPlugin.setSelectorDisable(128)
-        const selector = poolPlugin.interface.getSighash('beforeInitialize');
+        const selector = poolPlugin.interface.getFunction('beforeInitialize').selector;
         await expect(pool.initialize(encodePriceSqrt(1,1))).to.be.revertedWithCustomError(pool, "invalidHookResponse").withArgs(selector);
       })
 
       it('transaction reverted if plugin returns incorrect selector for afterInitialized hook', async () => {
         await poolPlugin.setSelectorDisable(64)
-        const selector = poolPlugin.interface.getSighash('afterInitialize');
+        const selector = poolPlugin.interface.getFunction('afterInitialize').selector
         await expect(pool.initialize(encodePriceSqrt(1,1))).to.be.revertedWithCustomError(pool, "invalidHookResponse").withArgs(selector)
       })
 
       it('transaction reverted if plugin returns incorrect selector for beforeModifyPosition hook', async () => {
         await poolPlugin.setSelectorDisable(4)
         await pool.initialize(encodePriceSqrt(1, 1))
-        const selector = poolPlugin.interface.getSighash('beforeModifyPosition');
+        const selector = poolPlugin.interface.getFunction('beforeModifyPosition').selector
         await expect(mint(wallet.address, minTick, maxTick, expandTo18Decimals(1))).to.be.revertedWithCustomError(pool, "invalidHookResponse").withArgs(selector)
       })
 
       it('transaction reverted if plugin returns incorrect selector for afterModifyPosition hook', async () => {
         await poolPlugin.setSelectorDisable(8)
         await pool.initialize(encodePriceSqrt(1, 1))
-        const selector = poolPlugin.interface.getSighash('afterModifyPosition');
+        const selector = poolPlugin.interface.getFunction('afterModifyPosition').selector
         await expect(mint(wallet.address, minTick, maxTick, expandTo18Decimals(1))).to.be.revertedWithCustomError(pool, "invalidHookResponse").withArgs(selector)
       })
 
@@ -2514,7 +2519,7 @@ describe('AlgebraPool', () => {
         await pool.initialize(encodePriceSqrt(1, 1))
         await mint(wallet.address, minTick, maxTick, expandTo18Decimals(1))
         await poolPlugin.setSelectorDisable(1)
-        const selector = poolPlugin.interface.getSighash('beforeSwap');
+        const selector = poolPlugin.interface.getFunction('beforeSwap').selector;
         await expect(swapExact0For1(10000, wallet.address)).to.be.revertedWithCustomError(pool, "invalidHookResponse").withArgs(selector)
       })
 
@@ -2522,7 +2527,7 @@ describe('AlgebraPool', () => {
         await pool.initialize(encodePriceSqrt(1, 1))
         await mint(wallet.address, minTick, maxTick, expandTo18Decimals(1))
         await poolPlugin.setSelectorDisable(2)
-        const selector = poolPlugin.interface.getSighash('afterSwap');
+        const selector = poolPlugin.interface.getFunction('afterSwap').selector
         await expect(swapExact0For1(10000, wallet.address)).to.be.revertedWithCustomError(pool, "invalidHookResponse").withArgs(selector)
       })
 
@@ -2530,7 +2535,7 @@ describe('AlgebraPool', () => {
         await pool.initialize(encodePriceSqrt(1, 1))
         await mint(wallet.address, minTick, maxTick, expandTo18Decimals(1))
         await poolPlugin.setSelectorDisable(16)
-        const selector = poolPlugin.interface.getSighash('beforeFlash');
+        const selector = poolPlugin.interface.getFunction('beforeFlash').selector
         await expect(flash(100, 200, other.address)).to.be.revertedWithCustomError(pool, "invalidHookResponse").withArgs(selector)
       })
 
@@ -2538,7 +2543,7 @@ describe('AlgebraPool', () => {
         await pool.initialize(encodePriceSqrt(1, 1))
         await mint(wallet.address, minTick, maxTick, expandTo18Decimals(1))
         await poolPlugin.setSelectorDisable(32)
-        const selector = poolPlugin.interface.getSighash('afterFlash');
+        const selector = poolPlugin.interface.getFunction('afterFlash').selector
         await expect(flash(100, 200, other.address)).to.be.revertedWithCustomError(pool, "invalidHookResponse").withArgs(selector)
       })
 
@@ -2585,8 +2590,8 @@ describe('AlgebraPool', () => {
 
       beforeEach('create plugin', async () => {
         const MockPoolPluginFactory = await ethers.getContractFactory('MockPoolPlugin');
-        poolPlugin = (await MockPoolPluginFactory.deploy(pool.address)) as MockPoolPlugin;
-        await pool.setPlugin(poolPlugin.address);
+        poolPlugin = (await MockPoolPluginFactory.deploy(pool)) as MockPoolPlugin;
+        await pool.setPlugin(poolPlugin);
         await pool.setPluginConfig(255);
       });
 
@@ -2634,7 +2639,7 @@ describe('AlgebraPool', () => {
       ).deploy()) as TestAlgebraReentrantCallee;
 
       // the tests happen in solidity
-      await expect(reentrant.swapToReenter(pool.address)).to.be.revertedWith('Unable to reenter');
+      await expect(reentrant.swapToReenter(pool)).to.be.revertedWith('Unable to reenter');
     });
   });
 
@@ -2644,25 +2649,25 @@ describe('AlgebraPool', () => {
       await mint(wallet.address, minTick, maxTick, 1);
       const [reserve0before, reserve1before] = await pool.getReserves();
 
-      await flash(0, 0, wallet.address, MaxUint128.sub(1), MaxUint128.sub(1));
+      await flash(0, 0, wallet.address, MaxUint128- 1n, MaxUint128- 1n);
 
-      await pool.burn(minTick, maxTick, 0, []);
+      await pool.burn(minTick, maxTick, 0, '0x');
       const [totalFeeGrowth0Token, totalFeeGrowth1Token] = await Promise.all([
         pool.totalFeeGrowth0Token(),
         pool.totalFeeGrowth1Token(),
       ]);
       // all 1s in first 128 bits
-      expect(totalFeeGrowth0Token).to.eq(MaxUint128.shl(128).sub(reserve0before.shl(128)));
-      expect(totalFeeGrowth1Token).to.eq(MaxUint128.shl(128).sub(reserve1before.shl(128)));
-      const { amount0, amount1 } = await pool.callStatic.collect(
+      expect(totalFeeGrowth0Token).to.eq((MaxUint128 << 128n) - (reserve0before << 128n));
+      expect(totalFeeGrowth1Token).to.eq((MaxUint128 << 128n) - (reserve1before << 128n));
+      const { amount0, amount1 } = await pool.collect.staticCall(
         wallet.address,
         minTick,
         maxTick,
         MaxUint128,
         MaxUint128
       );
-      expect(amount0).to.eq(MaxUint128.sub(1));
-      expect(amount1).to.eq(MaxUint128.sub(1));
+      expect(amount0).to.eq(MaxUint128- 1n);
+      expect(amount1).to.eq(MaxUint128- 1n);
     });
 
     it('reserves overflow max uint 128', async () => {
@@ -2673,15 +2678,15 @@ describe('AlgebraPool', () => {
       await flash(0, 0, wallet.address, MaxUint128, MaxUint128);
       await flash(0, 0, wallet.address, 1, 1);
 
-      await pool.burn(minTick, maxTick, 0, []);
+      await pool.burn(minTick, maxTick, 0, '0x');
       const [totalFeeGrowth0Token, totalFeeGrowth1Token] = await Promise.all([
         pool.totalFeeGrowth0Token(),
         pool.totalFeeGrowth1Token(),
       ]);
       // all 1s in first 128 bits
-      expect(totalFeeGrowth0Token).to.eq(MaxUint128.shl(128).sub(reserve0before.shl(128)));
-      expect(totalFeeGrowth1Token).to.eq(MaxUint128.shl(128).sub(reserve0before.shl(128)));
-      const { amount0, amount1 } = await pool.callStatic.collect(
+      expect(totalFeeGrowth0Token).to.eq((MaxUint128 << 128n) - (reserve0before << 128n));
+      expect(totalFeeGrowth1Token).to.eq((MaxUint128 << 128n) - (reserve1before << 128n));
+      const { amount0, amount1 } = await pool.collect.staticCall(
         wallet.address,
         minTick,
         maxTick,
@@ -2689,19 +2694,19 @@ describe('AlgebraPool', () => {
         MaxUint128
       );
       // fees burned
-      expect(amount0).to.eq(MaxUint128.sub(1));
-      expect(amount1).to.eq(MaxUint128.sub(1));
+      expect(amount0).to.eq(MaxUint128- 1n);
+      expect(amount1).to.eq(MaxUint128- 1n);
     });
 
     it('overflow max uint 128 after poke burns fees owed to 0', async () => {
       await pool.initialize(encodePriceSqrt(1, 1));
       await mint(wallet.address, minTick, maxTick, 1);
       await flash(0, 0, wallet.address, MaxUint128, MaxUint128);
-      await pool.burn(minTick, maxTick, 0, []);
+      await pool.burn(minTick, maxTick, 0, '0x');
       await flash(0, 0, wallet.address, 1, 1);
-      await pool.burn(minTick, maxTick, 0, []);
+      await pool.burn(minTick, maxTick, 0, '0x');
 
-      const { amount0, amount1 } = await pool.callStatic.collect(
+      const { amount0, amount1 } = await pool.collect.staticCall(
         wallet.address,
         minTick,
         maxTick,
@@ -2709,8 +2714,8 @@ describe('AlgebraPool', () => {
         MaxUint128
       );
       // fees burned
-      expect(amount0).to.eq(MaxUint128.sub(1));
-      expect(amount1).to.eq(MaxUint128.sub(1));
+      expect(amount0).to.eq(MaxUint128- 1n);
+      expect(amount1).to.eq(MaxUint128- 1n);
     });
 
     it('two positions at the same snapshot', async () => {
@@ -2720,18 +2725,18 @@ describe('AlgebraPool', () => {
       const [reserve0before] = await pool.getReserves();
       await flash(0, 0, wallet.address, MaxUint128, 0);
       await flash(0, 0, wallet.address, MaxUint128, 0);
-      await pool.burn(minTick, maxTick, 0, []);
+      await pool.burn(minTick, maxTick, 0, '0x');
       const totalFeeGrowth0Token = await pool.totalFeeGrowth0Token();
-      expect(totalFeeGrowth0Token).to.eq(MaxUint128.shl(128).sub(reserve0before.shl(128)).div(2));
+      expect(totalFeeGrowth0Token).to.eq(((MaxUint128 << 128n) - (reserve0before << 128n)) / 2n);
       await flash(0, 0, wallet.address, 2, 0);
-      await pool.burn(minTick, maxTick, 0, []);
-      await pool.connect(other).burn(minTick, maxTick, 0, []);
-      let { amount0 } = await pool.callStatic.collect(wallet.address, minTick, maxTick, MaxUint128, MaxUint128);
-      expect(amount0, 'amount0 of wallet').to.eq(MaxUint128.div(2).sub(1));
+      await pool.burn(minTick, maxTick, 0, '0x');
+      await pool.connect(other).burn(minTick, maxTick, 0, '0x');
+      let { amount0 } = await pool.collect.staticCall(wallet.address, minTick, maxTick, MaxUint128, MaxUint128);
+      expect(amount0, 'amount0 of wallet').to.eq(MaxUint128 / 2n- 1n);
       ({ amount0 } = await pool
         .connect(other)
-        .callStatic.collect(other.address, minTick, maxTick, MaxUint128, MaxUint128));
-      expect(amount0, 'amount0 of other').to.eq(MaxUint128.div(2).sub(1));
+        .collect.staticCall(other.address, minTick, maxTick, MaxUint128, MaxUint128));
+      expect(amount0, 'amount0 of other').to.eq(MaxUint128 / 2n- 1n);
     });
 
     it('two positions 1 wei of fees apart', async () => {
@@ -2742,113 +2747,115 @@ describe('AlgebraPool', () => {
       const totalFeeGrowth0TokenBefore = await pool.totalFeeGrowth0Token();
       await flash(0, 0, wallet.address, MaxUint128, 0);
       await flash(0, 0, wallet.address, MaxUint128, 0);
-      await pool.burn(minTick, maxTick, 0, []);
+      await pool.burn(minTick, maxTick, 0, '0x');
       const totalFeeGrowth0Token = await pool.totalFeeGrowth0Token();
-      expect(totalFeeGrowth0Token).to.eq(totalFeeGrowth0TokenBefore.add(MaxUint128.sub(3).shl(128).div(2)));
+      expect(totalFeeGrowth0Token).to.eq(totalFeeGrowth0TokenBefore + (((MaxUint128 - 3n) << 128n) / 2n));
       await flash(0, 0, wallet.address, 2, 0);
-      await pool.burn(minTick, maxTick, 0, []);
-      await pool.connect(other).burn(minTick, maxTick, 0, []);
-      let { amount0 } = await pool.callStatic.collect(wallet.address, minTick, maxTick, MaxUint128, MaxUint128);
-      expect(amount0, 'amount0 of wallet').to.eq(MaxUint128.div(2));
+      await pool.burn(minTick, maxTick, 0, '0x');
+      await pool.connect(other).burn(minTick, maxTick, 0, '0x');
+      let { amount0 } = await pool.collect.staticCall(wallet.address, minTick, maxTick, MaxUint128, MaxUint128);
+      expect(amount0, 'amount0 of wallet').to.eq(MaxUint128 / 2n);
       ({ amount0 } = await pool
         .connect(other)
-        .callStatic.collect(other.address, minTick, maxTick, MaxUint128, MaxUint128));
-      expect(amount0, 'amount0 of other').to.eq(MaxUint128.div(2).sub(1));
+        .collect.staticCall(other.address, minTick, maxTick, MaxUint128, MaxUint128));
+      expect(amount0, 'amount0 of other').to.eq(MaxUint128 / 2n- 1n);
     });
   });
 
   describe('swap underpayment tests', () => {
     let underpay: TestAlgebraSwapPay;
+    let poolAddress: string;
     beforeEach('deploy swap test', async () => {
       const underpayFactory = await ethers.getContractFactory('TestAlgebraSwapPay');
       underpay = (await underpayFactory.deploy()) as TestAlgebraSwapPay;
-      await token0.approve(underpay.address, constants.MaxUint256);
-      await token1.approve(underpay.address, constants.MaxUint256);
+      await token0.approve(underpay, MaxUint256);
+      await token1.approve(underpay, MaxUint256);
       await pool.initialize(encodePriceSqrt(1, 1));
       await mint(wallet.address, minTick, maxTick, expandTo18Decimals(1));
+      poolAddress = await pool.getAddress();
     });
     it('swap 0 tokens', async () => {
       await expect(
-        underpay.swap(pool.address, wallet.address, true, MIN_SQRT_RATIO.add(1), 0, 1, 0)
+        underpay.swap(pool, wallet.address, true, MIN_SQRT_RATIO + 1n, 0, 1, 0)
       ).to.be.revertedWithCustomError(pool, 'zeroAmountRequired');
     });
 
     it('underpay zero for one and exact in', async () => {
       await expect(
-        underpay.swap(pool.address, wallet.address, true, MIN_SQRT_RATIO.add(1), 1000, 1, 0)
+        underpay.swap(pool, wallet.address, true, MIN_SQRT_RATIO + 1n, 1000, 1, 0)
       ).to.be.revertedWithCustomError(pool, 'insufficientInputAmount');
     });
     it('underpay hardly zero for one and exact in supporting fee on transfer', async () => {
       await expect(
-        underpay.swapSupportingFee(pool.address, wallet.address, true, MIN_SQRT_RATIO.add(1), 1000, 0, 0)
+        underpay.swapSupportingFee(pool, wallet.address, true, MIN_SQRT_RATIO + 1n, 1000, 0, 0)
       ).to.be.revertedWithCustomError(pool, 'insufficientInputAmount');
     });
     it('underpay zero for one and exact in supporting fee on transfer', async () => {
-      await expect(underpay.swapSupportingFee(pool.address, wallet.address, true, MIN_SQRT_RATIO.add(1), 1000, 900, 0))
+      await expect(underpay.swapSupportingFee(pool, wallet.address, true, MIN_SQRT_RATIO + 1n, 1000, 900, 0))
         .to.be.not.reverted;
     });
     it('pay in the wrong token zero for one and exact in', async () => {
       await expect(
-        underpay.swap(pool.address, wallet.address, true, MIN_SQRT_RATIO.add(1), 1000, 0, 2000)
+        underpay.swap(pool, wallet.address, true, MIN_SQRT_RATIO + 1n, 1000, 0, 2000)
       ).to.be.revertedWithCustomError(pool, 'insufficientInputAmount');
     });
     it('overpay zero for one and exact in', async () => {
       await expect(
-        underpay.swap(pool.address, wallet.address, true, MIN_SQRT_RATIO.add(1), 1000, 2000, 0)
+        underpay.swap(pool, wallet.address, true, MIN_SQRT_RATIO + 1n, 1000, 2000, 0)
       ).to.not.be.revertedWithCustomError(pool, 'insufficientInputAmount');
     });
     it('underpay zero for one and exact out', async () => {
       await expect(
-        underpay.swap(pool.address, wallet.address, true, MIN_SQRT_RATIO.add(1), -1000, 1, 0)
+        underpay.swap(pool, wallet.address, true, MIN_SQRT_RATIO + 1n, -1000, 1, 0)
       ).to.be.revertedWithCustomError(pool, 'insufficientInputAmount');
     });
     it('pay in the wrong token zero for one and exact out', async () => {
       await expect(
-        underpay.swap(pool.address, wallet.address, true, MIN_SQRT_RATIO.add(1), -1000, 0, 2000)
+        underpay.swap(pool, wallet.address, true, MIN_SQRT_RATIO + 1n, -1000, 0, 2000)
       ).to.be.revertedWithCustomError(pool, 'insufficientInputAmount');
     });
     it('overpay zero for one and exact out', async () => {
       await expect(
-        underpay.swap(pool.address, wallet.address, true, MIN_SQRT_RATIO.add(1), -1000, 2000, 0)
+        underpay.swap(pool, wallet.address, true, MIN_SQRT_RATIO + 1n, -1000, 2000, 0)
       ).to.not.be.revertedWithCustomError(pool, 'insufficientInputAmount');
     });
     it('underpay one for zero and exact in', async () => {
       await expect(
-        underpay.swap(pool.address, wallet.address, false, MAX_SQRT_RATIO.sub(1), 1000, 0, 1)
+        underpay.swap(pool, wallet.address, false, MAX_SQRT_RATIO- 1n, 1000, 0, 1)
       ).to.be.revertedWithCustomError(pool, 'insufficientInputAmount');
     });
     it('underpay hardly one for zero and exact in supporting fee on transfer', async () => {
       await expect(
-        underpay.swapSupportingFee(pool.address, wallet.address, false, MAX_SQRT_RATIO.sub(1), 1000, 0, 0)
+        underpay.swapSupportingFee(pool, wallet.address, false, MAX_SQRT_RATIO- 1n, 1000, 0, 0)
       ).to.be.revertedWithCustomError(pool, 'insufficientInputAmount');
     });
     it('underpay one for zero and exact in supporting fee on transfer', async () => {
-      await expect(underpay.swapSupportingFee(pool.address, wallet.address, false, MAX_SQRT_RATIO.sub(1), 1000, 0, 990))
+      await expect(underpay.swapSupportingFee(pool, wallet.address, false, MAX_SQRT_RATIO- 1n, 1000, 0, 990))
         .to.be.not.reverted;
     });
     it('pay in the wrong token one for zero and exact in', async () => {
       await expect(
-        underpay.swap(pool.address, wallet.address, false, MAX_SQRT_RATIO.sub(1), 1000, 2000, 0)
+        underpay.swap(pool, wallet.address, false, MAX_SQRT_RATIO- 1n, 1000, 2000, 0)
       ).to.be.revertedWithCustomError(pool, 'insufficientInputAmount');
     });
     it('overpay one for zero and exact in', async () => {
       await expect(
-        underpay.swap(pool.address, wallet.address, false, MAX_SQRT_RATIO.sub(1), 1000, 0, 2000)
+        underpay.swap(pool, wallet.address, false, MAX_SQRT_RATIO- 1n, 1000, 0, 2000)
       ).to.not.be.revertedWithCustomError(pool, 'insufficientInputAmount');
     });
     it('underpay one for zero and exact out', async () => {
       await expect(
-        underpay.swap(pool.address, wallet.address, false, MAX_SQRT_RATIO.sub(1), -1000, 0, 1)
+        underpay.swap(pool, wallet.address, false, MAX_SQRT_RATIO- 1n, -1000, 0, 1)
       ).to.be.revertedWithCustomError(pool, 'insufficientInputAmount');
     });
     it('pay in the wrong token one for zero and exact out', async () => {
       await expect(
-        underpay.swap(pool.address, wallet.address, false, MAX_SQRT_RATIO.sub(1), -1000, 2000, 0)
+        underpay.swap(pool, wallet.address, false, MAX_SQRT_RATIO- 1n, -1000, 2000, 0)
       ).to.be.revertedWithCustomError(pool, 'insufficientInputAmount');
     });
     it('overpay one for zero and exact out', async () => {
       await expect(
-        underpay.swap(pool.address, wallet.address, false, MAX_SQRT_RATIO.sub(1), -1000, 0, 2000)
+        underpay.swap(pool, wallet.address, false, MAX_SQRT_RATIO- 1n, -1000, 0, 2000)
       ).to.not.be.revertedWithCustomError(pool, 'insufficientInputAmount');
     });
   });

--- a/src/core/test/AlgebraPool.spec.ts
+++ b/src/core/test/AlgebraPool.spec.ts
@@ -184,7 +184,7 @@ describe('AlgebraPool', () => {
 
           beforeEach(async () => {
             const factory = await ethers.getContractFactory('TestAlgebraSwapPay');
-            payer = (await factory.deploy()) as TestAlgebraSwapPay;
+            payer = (await factory.deploy()) as any as TestAlgebraSwapPay;
             await token0.approve(payer, 2n ** 256n - 1n);
             await token1.approve(payer, 2n ** 256n - 1n);
           });
@@ -328,7 +328,7 @@ describe('AlgebraPool', () => {
 
         it('refund if overpayment', async () => {
           const factory = await ethers.getContractFactory('TestAlgebraSwapPay');
-          let payer = (await factory.deploy()) as TestAlgebraSwapPay;
+          let payer = (await factory.deploy()) as any as TestAlgebraSwapPay;
           await token0.approve(payer, 2n ** 256n - 1n);
           await token1.approve(payer, 2n ** 256n - 1n);
 
@@ -351,7 +351,7 @@ describe('AlgebraPool', () => {
 
         it('do not refund if not overpaid', async () => {
           const factory = await ethers.getContractFactory('TestAlgebraSwapPay');
-          let payer = (await factory.deploy()) as TestAlgebraSwapPay;
+          let payer = (await factory.deploy()) as any as TestAlgebraSwapPay;
           await token0.approve(payer, 2n ** 256n - 1n);
           await token1.approve(payer, 2n ** 256n - 1n);
 
@@ -376,7 +376,7 @@ describe('AlgebraPool', () => {
           // TODO improve tests, check liquiditys
           beforeEach(async () => {
             const factory = await ethers.getContractFactory('TestAlgebraSwapPay');
-            payer = (await factory.deploy()) as TestAlgebraSwapPay;
+            payer = (await factory.deploy()) as any as TestAlgebraSwapPay;
             await token0.approve(payer, 2n ** 256n - 1n);
             await token1.approve(payer, 2n ** 256n - 1n);
           });
@@ -1938,7 +1938,7 @@ describe('AlgebraPool', () => {
   });
 
   it('tickMath handles tick overflow', async () => {
-    const sqrtTickMath = (await (await ethers.getContractFactory('TickMathTest')).deploy()) as TickMathTest;
+    const sqrtTickMath = (await (await ethers.getContractFactory('TickMathTest')).deploy()) as any as TickMathTest;
     await expect(sqrtTickMath.getSqrtRatioAtTick(887273)).to.be.revertedWithCustomError(sqrtTickMath, 'tickOutOfRange');
     await expect(sqrtTickMath.getSqrtRatioAtTick(-887273)).to.be.revertedWithCustomError(
       sqrtTickMath,
@@ -1948,10 +1948,10 @@ describe('AlgebraPool', () => {
 
   it('tick transition cannot run twice if zero for one swap ends at fractional price just below tick', async () => {
     pool = await createPoolWrapped();
-    const sqrtTickMath = (await (await ethers.getContractFactory('TickMathTest')).deploy()) as TickMathTest;
+    const sqrtTickMath = (await (await ethers.getContractFactory('TickMathTest')).deploy()) as any as TickMathTest;
     const PriceMovementMath = (await (
       await ethers.getContractFactory('PriceMovementMathTest')
-    ).deploy()) as PriceMovementMathTest;
+    ).deploy()) as any as PriceMovementMathTest;
     const p0 = (await sqrtTickMath.getSqrtRatioAtTick(-24081)) + 1n;
     // initialize at a price of ~0.3 token1/token0
     // meaning if you swap in 2 token0, you should end up getting 0 token1
@@ -2004,7 +2004,7 @@ describe('AlgebraPool', () => {
 
     it('works with plugin', async () => {
       const MockPoolPluginFactory = await ethers.getContractFactory('MockPoolPlugin');
-      const poolPlugin = (await MockPoolPluginFactory.deploy(await pool.getAddress())) as MockPoolPlugin;
+      const poolPlugin = (await MockPoolPluginFactory.deploy(await pool.getAddress())) as any as MockPoolPlugin;
       await pool.setPlugin(poolPlugin);
       await pool.setPluginConfig(255);
 
@@ -2391,7 +2391,7 @@ describe('AlgebraPool', () => {
       let callbackData: string
       beforeEach('create plugin', async () => {
         const MockPoolPluginFactory = await ethers.getContractFactory('MockPoolPlugin');
-        poolPlugin = (await MockPoolPluginFactory.deploy(pool)) as MockPoolPlugin;
+        poolPlugin = (await MockPoolPluginFactory.deploy(pool)) as any as MockPoolPlugin;
         await pool.setPlugin(poolPlugin);
         await pool.setPluginConfig(255);
         callbackData = encodeCallback(wallet.address)
@@ -2590,7 +2590,7 @@ describe('AlgebraPool', () => {
 
       beforeEach('create plugin', async () => {
         const MockPoolPluginFactory = await ethers.getContractFactory('MockPoolPlugin');
-        poolPlugin = (await MockPoolPluginFactory.deploy(pool)) as MockPoolPlugin;
+        poolPlugin = (await MockPoolPluginFactory.deploy(pool)) as any as MockPoolPlugin;
         await pool.setPlugin(poolPlugin);
         await pool.setPluginConfig(255);
       });
@@ -2636,7 +2636,7 @@ describe('AlgebraPool', () => {
     it('cannot reenter from swap callback', async () => {
       const reentrant = (await (
         await ethers.getContractFactory('TestAlgebraReentrantCallee')
-      ).deploy()) as TestAlgebraReentrantCallee;
+      ).deploy()) as any as TestAlgebraReentrantCallee;
 
       // the tests happen in solidity
       await expect(reentrant.swapToReenter(pool)).to.be.revertedWith('Unable to reenter');
@@ -2767,7 +2767,7 @@ describe('AlgebraPool', () => {
     let poolAddress: string;
     beforeEach('deploy swap test', async () => {
       const underpayFactory = await ethers.getContractFactory('TestAlgebraSwapPay');
-      underpay = (await underpayFactory.deploy()) as TestAlgebraSwapPay;
+      underpay = (await underpayFactory.deploy()) as any as TestAlgebraSwapPay;
       await token0.approve(underpay, MaxUint256);
       await token1.approve(underpay, MaxUint256);
       await pool.initialize(encodePriceSqrt(1, 1));

--- a/src/core/test/AlgebraPool.swaps.spec.ts
+++ b/src/core/test/AlgebraPool.swaps.spec.ts
@@ -1,5 +1,5 @@
 import { Decimal } from 'decimal.js';
-import { BigNumber, BigNumberish, ContractTransaction, Wallet } from 'ethers';
+import { ContractTransactionReceipt, ContractTransactionResponse, EventLog, Wallet, ZeroAddress } from 'ethers';
 import { ethers } from 'hardhat';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { MockTimeAlgebraPool, TestERC20, TestAlgebraCallee } from '../typechain';
@@ -26,42 +26,42 @@ const { constants } = ethers;
 
 interface BaseSwapTestCase {
   zeroToOne: boolean;
-  sqrtPriceLimit?: BigNumber;
+  sqrtPriceLimit?: bigint;
   targetTick?: number;
 }
 interface SwapExact0For1TestCase extends BaseSwapTestCase {
   zeroToOne: true;
   exactOut: false;
-  amount0: BigNumberish;
-  sqrtPriceLimit?: BigNumber;
+  amount0: bigint;
+  sqrtPriceLimit?: bigint;
   comissionOnTransaction: boolean;
 }
 interface SwapExact1For0TestCase extends BaseSwapTestCase {
   zeroToOne: false;
   exactOut: false;
-  amount1: BigNumberish;
-  sqrtPriceLimit?: BigNumber;
+  amount1: bigint;
+  sqrtPriceLimit?: bigint;
   comissionOnTransaction: boolean;
 }
 interface Swap0ForExact1TestCase extends BaseSwapTestCase {
   zeroToOne: true;
   exactOut: true;
-  amount1: BigNumberish;
-  sqrtPriceLimit?: BigNumber;
+  amount1: bigint;
+  sqrtPriceLimit?: bigint;
 }
 interface Swap1ForExact0TestCase extends BaseSwapTestCase {
   zeroToOne: false;
   exactOut: true;
-  amount0: BigNumberish;
-  sqrtPriceLimit?: BigNumber;
+  amount0: bigint;
+  sqrtPriceLimit?: bigint;
 }
 interface SwapToHigherPrice extends BaseSwapTestCase {
   zeroToOne: false;
-  sqrtPriceLimit?: BigNumber;
+  sqrtPriceLimit?: bigint;
 }
 interface SwapToLowerPrice extends BaseSwapTestCase {
   zeroToOne: true;
-  sqrtPriceLimit?: BigNumber;
+  sqrtPriceLimit?: bigint;
 }
 type SwapTestCase =
   | SwapExact0For1TestCase
@@ -111,15 +111,15 @@ function swapCaseToDescription(testCase: SwapTestCase): string {
 type PoolFunctions = ReturnType<typeof createPoolFunctions>;
 
 // can't use address zero because the ERC20 token does not allow it
-const SWAP_RECIPIENT_ADDRESS = constants.AddressZero.slice(0, -1) + '1';
-const POSITION_PROCEEDS_OUTPUT_ADDRESS = constants.AddressZero.slice(0, -1) + '2';
+const SWAP_RECIPIENT_ADDRESS = ZeroAddress.slice(0, -1) + '1';
+const POSITION_PROCEEDS_OUTPUT_ADDRESS = ZeroAddress.slice(0, -1) + '2';
 
 async function executeSwap(
   testCase: SwapTestCase,
   poolFunctions: PoolFunctions,
   testCallee: TestAlgebraCallee
-): Promise<ContractTransaction> {
-  let swap: ContractTransaction;
+): Promise<ContractTransactionResponse> {
+  let swap: ContractTransactionResponse;
   if ('exactOut' in testCase) {
     if (testCase.exactOut) {
       if (testCase.zeroToOne) {
@@ -234,48 +234,48 @@ const DEFAULT_POOL_SWAP_TESTS: SwapTestCase[] = [
   {
     zeroToOne: true,
     exactOut: false,
-    amount0: 1000,
+    amount0: 1000n,
     comissionOnTransaction: false,
   },
   {
     zeroToOne: true,
     exactOut: false,
-    amount0: 1000,
+    amount0: 1000n,
     comissionOnTransaction: true,
   },
   {
     zeroToOne: true,
     exactOut: false,
-    amount0: 1,
+    amount0: 1n,
     comissionOnTransaction: true,
   },
   {
     zeroToOne: false,
     exactOut: false,
-    amount1: 1000,
+    amount1: 1000n,
     comissionOnTransaction: false,
   },
   {
     zeroToOne: false,
     exactOut: false,
-    amount1: 1,
+    amount1: 1n,
     comissionOnTransaction: false,
   },
   {
     zeroToOne: false,
     exactOut: false,
-    amount1: 1000,
+    amount1: 1000n,
     comissionOnTransaction: true,
   },
   {
     zeroToOne: true,
     exactOut: true,
-    amount1: 1000,
+    amount1: 1000n,
   },
   {
     zeroToOne: false,
     exactOut: true,
-    amount0: 1000,
+    amount0: 1000n,
   },
   // swap arbitrary input to price
   {
@@ -317,14 +317,14 @@ const DEFAULT_POOL_SWAP_TESTS: SwapTestCase[] = [
 interface Position {
   bottomTick: number;
   topTick: number;
-  liquidity: BigNumberish;
+  liquidity: bigint;
 }
 
 interface PoolTestCase {
   description: string;
   feeAmount: number;
   tickSpacing: number;
-  startingPrice: BigNumber;
+  startingPrice: bigint;
   positions: Position[];
   swapTests?: SwapTestCase[];
 }
@@ -453,7 +453,7 @@ const TEST_POOLS: PoolTestCase[] = [
     description: 'close to max price',
     feeAmount: FeeAmount.MEDIUM,
     tickSpacing: TICK_SPACINGS[FeeAmount.MEDIUM],
-    startingPrice: encodePriceSqrt(BigNumber.from(2).pow(127), 1),
+    startingPrice: encodePriceSqrt(2n ** 127n, 1),
     positions: [
       {
         bottomTick: getMinTick(TICK_SPACINGS[FeeAmount.MEDIUM]),
@@ -466,7 +466,7 @@ const TEST_POOLS: PoolTestCase[] = [
     description: 'close to min price',
     feeAmount: FeeAmount.MEDIUM,
     tickSpacing: TICK_SPACINGS[FeeAmount.MEDIUM],
-    startingPrice: encodePriceSqrt(1, BigNumber.from(2).pow(127)),
+    startingPrice: encodePriceSqrt(1, 2n ** 127n),
     positions: [
       {
         bottomTick: getMinTick(TICK_SPACINGS[FeeAmount.MEDIUM]),
@@ -484,7 +484,7 @@ const TEST_POOLS: PoolTestCase[] = [
       {
         bottomTick: getMinTick(TICK_SPACINGS[FeeAmount.MEDIUM]),
         topTick: getMaxTick(TICK_SPACINGS[FeeAmount.MEDIUM]),
-        liquidity: BigNumber.from('40564824043007195767232224305152'),
+        liquidity: BigInt('40564824043007195767232224305152'),
       },
     ],
   },
@@ -492,7 +492,7 @@ const TEST_POOLS: PoolTestCase[] = [
     description: 'initialized at the max ratio',
     feeAmount: FeeAmount.MEDIUM,
     tickSpacing: TICK_SPACINGS[FeeAmount.MEDIUM],
-    startingPrice: MAX_SQRT_RATIO.sub(1),
+    startingPrice: MAX_SQRT_RATIO - 1n,
     positions: [
       {
         bottomTick: getMinTick(TICK_SPACINGS[FeeAmount.MEDIUM]),
@@ -554,12 +554,13 @@ describe('AlgebraPool swap tests', () => {
         let _position = { ...position };
         let tx = await poolFunctions.mint(wallet.address, position.bottomTick, position.topTick, position.liquidity);
         let receipt = await tx.wait();
-        if (!receipt.events) continue;
+        if (!receipt?.logs) continue;
 
-        for (let ev of receipt.events) {
-          if (ev.event == 'MintResult') {
-            if (ev.args) {
-              _position.liquidity = ev.args[2];
+        for (let log of receipt.logs) {
+          if (!('eventName' in log)) continue;
+          if (log.eventName == 'MintResult') {
+            if (log.args) {
+              _position.liquidity = log.args[2];
             }
             break;
           }
@@ -568,8 +569,8 @@ describe('AlgebraPool swap tests', () => {
       }
 
       const [poolBalance0, poolBalance1] = await Promise.all([
-        token0.balanceOf(pool.address),
-        token1.balanceOf(pool.address),
+        token0.balanceOf(pool),
+        token1.balanceOf(pool),
       ]);
 
       return {
@@ -608,8 +609,8 @@ describe('AlgebraPool swap tests', () => {
       let token0: TestERC20;
       let token1: TestERC20;
 
-      let poolBalance0: BigNumber;
-      let poolBalance1: BigNumber;
+      let poolBalance0: bigint;
+      let poolBalance1: bigint;
 
       let pool: MockTimeAlgebraPool;
       let swapTarget: TestAlgebraCallee;
@@ -619,7 +620,7 @@ describe('AlgebraPool swap tests', () => {
 
       afterEach('check can burn positions', async () => {
         for (const { liquidity, topTick, bottomTick } of _positions) {
-          await pool.burn(bottomTick, topTick, liquidity, []);
+          await pool.burn(bottomTick, topTick, liquidity, '0x');
           await pool.collect(POSITION_PROCEEDS_OUTPUT_ADDRESS, bottomTick, topTick, MaxUint128, MaxUint128);
         }
       });
@@ -652,39 +653,39 @@ describe('AlgebraPool swap tests', () => {
             totalFeeGrowth0Token,
             totalFeeGrowth1Token,
           ] = await Promise.all([
-            token0.balanceOf(pool.address),
-            token1.balanceOf(pool.address),
+            token0.balanceOf(pool),
+            token1.balanceOf(pool),
             pool.globalState(),
             pool.liquidity(),
             pool.totalFeeGrowth0Token(),
             pool.totalFeeGrowth1Token(),
           ]);
-          const poolBalance0Delta = poolBalance0After.sub(poolBalance0);
-          const poolBalance1Delta = poolBalance1After.sub(poolBalance1);
+          const poolBalance0Delta = poolBalance0After - poolBalance0;
+          const poolBalance1Delta = poolBalance1After - poolBalance1;
 
           // check all the events were emitted corresponding to balance changes
 
           if (!withComission) {
-            if (poolBalance0Delta.eq(0)) await expect(tx).to.not.emit(token0, 'Transfer');
-            else if (poolBalance0Delta.lt(0))
+            if (poolBalance0Delta == 0n) await expect(tx).to.not.emit(token0, 'Transfer');
+            else if (poolBalance0Delta < 0n)
               await expect(tx)
                 .to.emit(token0, 'Transfer')
-                .withArgs(pool.address, SWAP_RECIPIENT_ADDRESS, poolBalance0Delta.mul(-1));
-            else await expect(tx).to.emit(token0, 'Transfer').withArgs(wallet.address, pool.address, poolBalance0Delta);
+                .withArgs(await pool.getAddress(), SWAP_RECIPIENT_ADDRESS, poolBalance0Delta * -1n);
+            else await expect(tx).to.emit(token0, 'Transfer').withArgs(wallet.address, await pool.getAddress(), poolBalance0Delta);
 
-            if (poolBalance1Delta.eq(0)) await expect(tx).to.not.emit(token1, 'Transfer');
-            else if (poolBalance1Delta.lt(0))
+            if (poolBalance1Delta == 0n) await expect(tx).to.not.emit(token1, 'Transfer');
+            else if (poolBalance1Delta < 0n)
               await expect(tx)
                 .to.emit(token1, 'Transfer')
-                .withArgs(pool.address, SWAP_RECIPIENT_ADDRESS, poolBalance1Delta.mul(-1));
-            else await expect(tx).to.emit(token1, 'Transfer').withArgs(wallet.address, pool.address, poolBalance1Delta);
+                .withArgs(await pool.getAddress(), SWAP_RECIPIENT_ADDRESS, poolBalance1Delta * -1n);
+            else await expect(tx).to.emit(token1, 'Transfer').withArgs(wallet.address, await pool.getAddress(), poolBalance1Delta);
           }
 
           // check that the swap event was emitted too
           await expect(tx)
             .to.emit(pool, 'Swap')
             .withArgs(
-              swapTarget.address,
+              await swapTarget.getAddress(),
               SWAP_RECIPIENT_ADDRESS,
               poolBalance0Delta,
               poolBalance1Delta,

--- a/src/core/test/AlgebraPool.swaps.spec.ts
+++ b/src/core/test/AlgebraPool.swaps.spec.ts
@@ -22,8 +22,6 @@ import {
 
 Decimal.config({ toExpNeg: -500, toExpPos: 500 });
 
-const { constants } = ethers;
-
 interface BaseSwapTestCase {
   zeroToOne: boolean;
   sqrtPriceLimit?: bigint;

--- a/src/core/test/AlgebraRouter.spec.ts
+++ b/src/core/test/AlgebraRouter.spec.ts
@@ -73,12 +73,12 @@ describe('AlgebraPoolRouter', () => {
   });
 
   it('constructor initializes immutables', async () => {
-    expect(await pool0.factory()).to.eq(factory.address);
-    expect(await pool0.token0()).to.eq(token0.address);
-    expect(await pool0.token1()).to.eq(token1.address);
-    expect(await pool1.factory()).to.eq(factory.address);
-    expect(await pool1.token0()).to.eq(token1.address);
-    expect(await pool1.token1()).to.eq(token2.address);
+    expect(await pool0.factory()).to.eq(await factory.getAddress());
+    expect(await pool0.token0()).to.eq(await token0.getAddress());
+    expect(await pool0.token1()).to.eq(await token1.getAddress());
+    expect(await pool1.factory()).to.eq(await factory.getAddress());
+    expect(await pool1.token0()).to.eq(await token1.getAddress());
+    expect(await pool1.token1()).to.eq(await token2.getAddress());
   });
 
   describe('multi-swaps', () => {
@@ -98,8 +98,8 @@ describe('AlgebraPoolRouter', () => {
 
     it('multi-swap', async () => {
       const token0OfPoolOutput = await pool1.token0();
-      expect(token0OfPoolOutput).to.be.oneOf([token1.address, token2.address]);
-      const ForExact0 = outputToken.address === token0OfPoolOutput;
+      expect(token0OfPoolOutput).to.be.oneOf([await token1.getAddress(), await token2.getAddress()]);
+      const ForExact0 = await outputToken.getAddress() === token0OfPoolOutput;
 
       const { swapForExact0Multi, swapForExact1Multi } = createMultiPoolFunctions({
         inputToken: token0,
@@ -110,13 +110,18 @@ describe('AlgebraPoolRouter', () => {
 
       const method = ForExact0 ? swapForExact0Multi : swapForExact1Multi;
 
+      const [pool0Address, pool1Address, inputTokenAddress] = [
+        await pool0.getAddress(),
+        await pool1.getAddress(),
+        await inputToken.getAddress()
+      ]
       await expect(method(100, wallet.address))
         .to.emit(outputToken, 'Transfer')
-        .withArgs(pool1.address, wallet.address, 100)
+        .withArgs(pool1Address, wallet.address, 100)
         .to.emit(token1, 'Transfer')
-        .withArgs(pool0.address, pool1.address, 102)
+        .withArgs(pool0Address, pool1Address, 102)
         .to.emit(inputToken, 'Transfer')
-        .withArgs(wallet.address, pool0.address, 104);
+        .withArgs(wallet.address, pool0Address, 104);
     });
   });
 });

--- a/src/core/test/AlgebraVault.spec.ts
+++ b/src/core/test/AlgebraVault.spec.ts
@@ -1,4 +1,4 @@
-import { Wallet, BigNumber } from 'ethers';
+import { Wallet, getCreateAddress, ZeroAddress } from 'ethers';
 import { ethers } from 'hardhat';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { AlgebraFactory, AlgebraPoolDeployer, AlgebraCommunityVault, TestERC20 } from '../typechain';
@@ -14,29 +14,29 @@ describe('AlgebraCommunityVault', () => {
   let token0: TestERC20;
   let token1: TestERC20;
 
-  const AMOUNT = BigNumber.from(10).pow(18);
+  const AMOUNT = 10n ** 18n;
 
   const fixture = async () => {
     const [deployer] = await ethers.getSigners();
     // precompute
-    const poolDeployerAddress = ethers.utils.getContractAddress({
+    const poolDeployerAddress = getCreateAddress({
       from: deployer.address,
-      nonce: (await deployer.getTransactionCount()) + 1,
+      nonce: (await ethers.provider.getTransactionCount(deployer.address)) + 1,
     });
 
     const factoryFactory = await ethers.getContractFactory('AlgebraFactory');
-    const _factory = (await factoryFactory.deploy(poolDeployerAddress)) as AlgebraFactory;
+    const _factory = (await factoryFactory.deploy(poolDeployerAddress)) as any as AlgebraFactory;
 
     const vaultAddress = await _factory.communityVault();
     const vaultFactory = await ethers.getContractFactory('AlgebraCommunityVault');
-    vault = vaultFactory.attach(vaultAddress) as AlgebraCommunityVault;
+    vault = vaultFactory.attach(vaultAddress) as any as AlgebraCommunityVault;
 
     const tokenFactory = await ethers.getContractFactory('TestERC20');
-    token0 = (await tokenFactory.deploy(BigNumber.from(2).pow(255))) as TestERC20;
-    token1 = (await tokenFactory.deploy(BigNumber.from(2).pow(255))) as TestERC20;
+    token0 = (await tokenFactory.deploy(2n ** 255n)) as any as TestERC20;
+    token1 = (await tokenFactory.deploy(2n ** 255n)) as any as TestERC20;
 
     const poolDeployerFactory = await ethers.getContractFactory('AlgebraPoolDeployer');
-    poolDeployer = (await poolDeployerFactory.deploy(_factory.address, vault.address)) as AlgebraPoolDeployer;
+    poolDeployer = (await poolDeployerFactory.deploy(_factory, vault)) as any as AlgebraPoolDeployer;
     return _factory;
   };
 
@@ -46,8 +46,8 @@ describe('AlgebraCommunityVault', () => {
 
   beforeEach('add tokens to vault', async () => {
     factory = await loadFixture(fixture);
-    await token0.transfer(vault.address, BigNumber.from(10).pow(18));
-    await token1.transfer(vault.address, BigNumber.from(10).pow(18));
+    await token0.transfer(vault, AMOUNT);
+    await token1.transfer(vault, AMOUNT);
   });
 
   describe('#Withdraw', async () => {
@@ -65,21 +65,21 @@ describe('AlgebraCommunityVault', () => {
       describe('Algebra fee off', async () => {
         it('withdraw works', async () => {
           let balanceBefore = await token0.balanceOf(communityFeeReceiver);
-          await vault.withdraw(token0.address, AMOUNT);
+          await vault.withdraw(token0, AMOUNT);
           let balanceAfter = await token0.balanceOf(communityFeeReceiver);
-          expect(balanceAfter.sub(balanceBefore)).to.eq(AMOUNT);
+          expect(balanceAfter - balanceBefore).to.eq(AMOUNT);
         });
 
         it('algebra fee manager can withdraw', async () => {
           let balanceBefore = await token0.balanceOf(communityFeeReceiver);
 
           const _vault = vault.connect(third);
-          await expect(_vault.withdraw(token0.address, AMOUNT)).to.be.reverted;
+          await expect(_vault.withdraw(token0, AMOUNT)).to.be.reverted;
 
-          await _vault.connect(other).withdraw(token0.address, AMOUNT);
+          await _vault.connect(other).withdraw(token0, AMOUNT);
 
           let balanceAfter = await token0.balanceOf(communityFeeReceiver);
-          expect(balanceAfter.sub(balanceBefore)).to.eq(AMOUNT);
+          expect(balanceAfter - balanceBefore).to.eq(AMOUNT);
         });
 
         it('withdrawTokens works', async () => {
@@ -87,24 +87,24 @@ describe('AlgebraCommunityVault', () => {
           let balance1Before = await token1.balanceOf(communityFeeReceiver);
           await vault.withdrawTokens([
             {
-              token: token0.address,
+              token: token0,
               amount: AMOUNT,
             },
             {
-              token: token1.address,
+              token: token1,
               amount: AMOUNT,
             },
           ]);
           let balance0After = await token0.balanceOf(communityFeeReceiver);
           let balance1After = await token1.balanceOf(communityFeeReceiver);
-          expect(balance0After.sub(balance0Before)).to.eq(AMOUNT);
-          expect(balance1After.sub(balance1Before)).to.eq(AMOUNT);
+          expect(balance0After - balance0Before).to.eq(AMOUNT);
+          expect(balance1After - balance1Before).to.eq(AMOUNT);
         });
       });
 
       describe('Algebra fee on', async () => {
         let algebraFeeReceiver: string;
-        const ALGEBRA_FEE = 100; // 10%
+        const ALGEBRA_FEE = 100n; // 10%
 
         beforeEach('turn on algebra fee', async () => {
           algebraFeeReceiver = other.address;
@@ -118,12 +118,12 @@ describe('AlgebraCommunityVault', () => {
           let balanceBefore = await token0.balanceOf(communityFeeReceiver);
           let balanceAlgebraBefore = await token0.balanceOf(algebraFeeReceiver);
 
-          await vault.withdraw(token0.address, AMOUNT);
+          await vault.withdraw(token0, AMOUNT);
           let balanceAfter = await token0.balanceOf(communityFeeReceiver);
           let balanceAlgebraAfter = await token0.balanceOf(algebraFeeReceiver);
 
-          expect(balanceAfter.sub(balanceBefore)).to.eq(AMOUNT.sub(AMOUNT.mul(ALGEBRA_FEE).div(1000)));
-          expect(balanceAlgebraAfter.sub(balanceAlgebraBefore)).to.eq(AMOUNT.mul(ALGEBRA_FEE).div(1000));
+          expect(balanceAfter - balanceBefore).to.eq(AMOUNT - (AMOUNT * ALGEBRA_FEE / 1000n));
+          expect(balanceAlgebraAfter - balanceAlgebraBefore).to.eq(AMOUNT * ALGEBRA_FEE / 1000n);
         });
 
         it('algebra fee manager can withdraw', async () => {
@@ -132,15 +132,15 @@ describe('AlgebraCommunityVault', () => {
 
           const _vault = vault.connect(third);
 
-          await expect(_vault.withdraw(token0.address, AMOUNT)).to.be.reverted;
+          await expect(_vault.withdraw(token0, AMOUNT)).to.be.reverted;
 
-          await expect(_vault.connect(other).withdraw(token0.address, AMOUNT))
+          await _vault.connect(other).withdraw(token0, AMOUNT)
 
           let balanceAfter = await token0.balanceOf(communityFeeReceiver);
           let balanceAlgebraAfter = await token0.balanceOf(algebraFeeReceiver);
 
-          expect(balanceAfter.sub(balanceBefore)).to.eq(AMOUNT.sub(AMOUNT.mul(ALGEBRA_FEE).div(1000)));
-          expect(balanceAlgebraAfter.sub(balanceAlgebraBefore)).to.eq(AMOUNT.mul(ALGEBRA_FEE).div(1000));
+          expect(balanceAfter - balanceBefore).to.eq(AMOUNT - (AMOUNT * ALGEBRA_FEE / 1000n));
+          expect(balanceAlgebraAfter - balanceAlgebraBefore).to.eq(AMOUNT * ALGEBRA_FEE / 1000n);
         });
 
         it('withdrawTokens works', async () => {
@@ -151,11 +151,11 @@ describe('AlgebraCommunityVault', () => {
 
           await vault.withdrawTokens([
             {
-              token: token0.address,
+              token: token0,
               amount: AMOUNT,
             },
             {
-              token: token1.address,
+              token: token1,
               amount: AMOUNT,
             },
           ]);
@@ -164,10 +164,10 @@ describe('AlgebraCommunityVault', () => {
           let balance0AlgebraAfter = await token0.balanceOf(algebraFeeReceiver);
           let balance1AlgebraAfter = await token1.balanceOf(algebraFeeReceiver);
 
-          expect(balance0After.sub(balance0Before)).to.eq(AMOUNT.sub(AMOUNT.mul(ALGEBRA_FEE).div(1000)));
-          expect(balance1After.sub(balance1Before)).to.eq(AMOUNT.sub(AMOUNT.mul(ALGEBRA_FEE).div(1000)));
-          expect(balance0AlgebraAfter.sub(balance0AlgebraBefore)).to.eq(AMOUNT.mul(ALGEBRA_FEE).div(1000));
-          expect(balance1AlgebraAfter.sub(balance1AlgebraBefore)).to.eq(AMOUNT.mul(ALGEBRA_FEE).div(1000));
+          expect(balance0After - balance0Before).to.eq(AMOUNT - (AMOUNT * ALGEBRA_FEE / 1000n));
+          expect(balance1After - balance1Before).to.eq(AMOUNT - (AMOUNT * ALGEBRA_FEE / 1000n));
+          expect(balance0AlgebraAfter - balance0AlgebraBefore).to.eq(AMOUNT * ALGEBRA_FEE / 1000n);
+          expect(balance1AlgebraAfter - balance1AlgebraBefore).to.eq(AMOUNT * ALGEBRA_FEE / 1000n);
         });
       });
     });
@@ -176,11 +176,11 @@ describe('AlgebraCommunityVault', () => {
       it('withdraw onlyWithdrawer', async () => {
         await vault.changeCommunityFeeReceiver(wallet.address);
         expect(await vault.communityFeeReceiver()).to.be.eq(wallet.address);
-        await expect(vault.connect(other).withdraw(token0.address, AMOUNT)).to.be.reverted;
+        await expect(vault.connect(other).withdraw(token0, AMOUNT)).to.be.reverted;
       });
 
       it('cannot withdraw without communityFeeReceiver', async () => {
-        await expect(vault.withdraw(token0.address, AMOUNT)).to.be.revertedWith('invalid receiver');
+        await expect(vault.withdraw(token0, AMOUNT)).to.be.revertedWith('invalid receiver');
       });
 
       it('withdrawTokens onlyWithdrawer', async () => {
@@ -189,7 +189,7 @@ describe('AlgebraCommunityVault', () => {
         await expect(
           vault.connect(other).withdrawTokens([
             {
-              token: token0.address,
+              token: token0,
               amount: AMOUNT,
             },
           ])
@@ -200,7 +200,7 @@ describe('AlgebraCommunityVault', () => {
         await expect(
           vault.withdrawTokens([
             {
-              token: token0.address,
+              token: token0,
               amount: AMOUNT,
             },
           ])
@@ -208,7 +208,7 @@ describe('AlgebraCommunityVault', () => {
       });
 
       describe('Algebra fee on', async () => {
-        const ALGEBRA_FEE = 100; // 10%
+        const ALGEBRA_FEE = 100n; // 10%
 
         beforeEach('turn on algebra fee', async () => {
           await vault.proposeAlgebraFeeChange(ALGEBRA_FEE);
@@ -218,7 +218,7 @@ describe('AlgebraCommunityVault', () => {
         it('cannot withdraw without algebraFeeReceiver', async () => {
           await vault.changeCommunityFeeReceiver(wallet.address);
           expect(await vault.communityFeeReceiver()).to.be.eq(wallet.address);
-          await expect(vault.withdraw(token0.address, AMOUNT)).to.be.revertedWith('invalid algebra fee receiver');
+          await expect(vault.withdraw(token0, AMOUNT)).to.be.revertedWith('invalid algebra fee receiver');
         });
 
         it('cannot withdrawTokens without algebraFeeReceiver', async () => {
@@ -227,7 +227,7 @@ describe('AlgebraCommunityVault', () => {
           await expect(
             vault.withdrawTokens([
               {
-                token: token0.address,
+                token: token0,
                 amount: AMOUNT,
               },
             ])
@@ -238,7 +238,7 @@ describe('AlgebraCommunityVault', () => {
   });
 
   describe('#FactoryOwner permissioned actions', async () => {
-    const ALGEBRA_FEE = 100; // 10%
+    const ALGEBRA_FEE = 100n; // 10%
 
     it('can accept fee change proposal', async () => {
       await vault.proposeAlgebraFeeChange(ALGEBRA_FEE);
@@ -255,7 +255,7 @@ describe('AlgebraCommunityVault', () => {
 
     it('can not accept invalid fee change proposal', async () => {
       await vault.proposeAlgebraFeeChange(ALGEBRA_FEE);
-      await expect(vault.acceptAlgebraFeeChangeProposal(ALGEBRA_FEE - 1)).to.be.revertedWith('invalid new fee');
+      await expect(vault.acceptAlgebraFeeChangeProposal(ALGEBRA_FEE - 1n)).to.be.revertedWith('invalid new fee');
     });
 
     it('can not accept fee if nothing proposed', async () => {
@@ -268,7 +268,7 @@ describe('AlgebraCommunityVault', () => {
     });
 
     it('can not change communityFeeReceiver to zero address', async () => {
-      await expect(vault.changeCommunityFeeReceiver(ethers.constants.AddressZero)).to.be.reverted;
+      await expect(vault.changeCommunityFeeReceiver(ZeroAddress)).to.be.reverted;
     });
 
     it('only factory owner can change communityFeeReceiver', async () => {
@@ -277,7 +277,7 @@ describe('AlgebraCommunityVault', () => {
   });
 
   describe('#AlgebraFeeManager permissioned actions', async () => {
-    const ALGEBRA_FEE = 100; // 10%
+    const ALGEBRA_FEE = 100n; // 10%
 
     it('can transfer AlgebraFeeManager role', async () => {
       await vault.transferAlgebraFeeManagerRole(other.address);
@@ -297,7 +297,7 @@ describe('AlgebraCommunityVault', () => {
 
     it('can change AlgebraFeeReceiver', async () => {
       await expect(vault.connect(other).changeAlgebraFeeReceiver(other.address)).to.be.reverted;
-      await expect(vault.changeAlgebraFeeReceiver(ethers.constants.AddressZero)).to.be.reverted;
+      await expect(vault.changeAlgebraFeeReceiver(ZeroAddress)).to.be.reverted;
 
       await vault.changeAlgebraFeeReceiver(other.address);
       expect(await vault.algebraFeeReceiver()).to.be.eq(other.address);

--- a/src/core/test/BitMath.spec.ts
+++ b/src/core/test/BitMath.spec.ts
@@ -4,13 +4,11 @@ import { ethers } from 'hardhat';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import snapshotGasCost from './shared/snapshotGasCost';
 
-const { BigNumber } = ethers;
-
 describe('BitMath', () => {
   let bitMath: BitMathTest;
   const fixture = async () => {
     const factory = await ethers.getContractFactory('BitMathTest');
-    return (await factory.deploy()) as BitMathTest;
+    return (await factory.deploy()) as any as BitMathTest;
   };
   beforeEach('deploy BitMathTest', async () => {
     bitMath = await loadFixture(fixture);
@@ -25,25 +23,25 @@ describe('BitMath', () => {
     });
     it('all powers of 2', async () => {
       const results = await Promise.all(
-        [...Array(255)].map((_, i) => bitMath.leastSignificantBit(BigNumber.from(2).pow(i)))
+        [...Array(255)].map((_, i) => bitMath.leastSignificantBit(2n ** BigInt(i)))
       );
       expect(results).to.deep.eq([...Array(255)].map((_, i) => i));
     });
     it('uint256(-1)', async () => {
-      expect(await bitMath.leastSignificantBit(BigNumber.from(2).pow(256).sub(1))).to.eq(0);
+      expect(await bitMath.leastSignificantBit(2n ** 256n - 1n)).to.eq(0);
     });
 
     it('gas cost of smaller number  [ @skip-on-coverage ]', async () => {
-      await snapshotGasCost(bitMath.getGasCostOfLeastSignificantBit(BigNumber.from(3568)));
+      await snapshotGasCost(bitMath.getGasCostOfLeastSignificantBit(3568n));
     });
     it('gas cost of min number  [ @skip-on-coverage ]', async () => {
-      await snapshotGasCost(bitMath.getGasCostOfLeastSignificantBit(BigNumber.from(1)));
+      await snapshotGasCost(bitMath.getGasCostOfLeastSignificantBit(1n));
     });
     it('gas cost of max uint128  [ @skip-on-coverage ]', async () => {
-      await snapshotGasCost(bitMath.getGasCostOfLeastSignificantBit(BigNumber.from(2).pow(128).sub(1)));
+      await snapshotGasCost(bitMath.getGasCostOfLeastSignificantBit(2n ** 128n - 1n));
     });
     it('gas cost of max uint256  [ @skip-on-coverage ]', async () => {
-      await snapshotGasCost(bitMath.getGasCostOfLeastSignificantBit(BigNumber.from(2).pow(256).sub(1)));
+      await snapshotGasCost(bitMath.getGasCostOfLeastSignificantBit(2n ** 256n - 1n));
     });
   });
 });

--- a/src/core/test/LiquidityMath.spec.ts
+++ b/src/core/test/LiquidityMath.spec.ts
@@ -4,13 +4,11 @@ import { ethers } from 'hardhat';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import snapshotGasCost from './shared/snapshotGasCost';
 
-const { BigNumber } = ethers;
-
 describe('LiquidityMath', () => {
   let liquidityMath: LiquidityMathTest;
   const fixture = async () => {
     const factory = await ethers.getContractFactory('LiquidityMathTest');
-    return (await factory.deploy()) as LiquidityMathTest;
+    return (await factory.deploy()) as any as LiquidityMathTest;
   };
   beforeEach('deploy LiquidityMathTest', async () => {
     liquidityMath = await loadFixture(fixture);
@@ -27,7 +25,7 @@ describe('LiquidityMath', () => {
       expect(await liquidityMath.addDelta(1, 1)).to.eq(2);
     });
     it('2**128-15 + 15 overflows', async () => {
-      await expect(liquidityMath.addDelta(BigNumber.from(2).pow(128).sub(15), 15)).to.be.revertedWithCustomError(
+      await expect(liquidityMath.addDelta(2n ** 128n - 15n, 15)).to.be.revertedWithCustomError(
         liquidityMath,
         'liquidityAdd'
       );

--- a/src/core/test/Math.spec.ts
+++ b/src/core/test/Math.spec.ts
@@ -1,13 +1,10 @@
 import { ethers } from 'hardhat';
+import { MaxUint256 } from 'ethers';
 import { SafeMathTest, FullMathTest } from '../typechain';
 import { expect } from './shared/expect';
 import { Decimal } from 'decimal.js';
 
-const {
-  BigNumber,
-  constants: { MaxUint256 },
-} = ethers;
-const Q128 = BigNumber.from(2).pow(128);
+const Q128 = 2n ** 128n;
 
 Decimal.config({ toExpNeg: -500, toExpPos: 500 });
 
@@ -16,16 +13,16 @@ describe('SafeMath', () => {
 
   before('deploy FullMathTest', async () => {
     const factory = await ethers.getContractFactory('SafeMathTest');
-    safeMath = (await factory.deploy()) as SafeMathTest;
+    safeMath = (await factory.deploy()) as any as SafeMathTest;
   });
 
   it('#add', async () => {
-    await expect(safeMath.add(BigNumber.from(2).pow(256).sub(1), 1)).to.be.reverted;
+    await expect(safeMath.add(MaxUint256, 1)).to.be.reverted;
   });
 
   it('#sub', async () => {
-    await expect(safeMath.sub(Q128.sub(1), Q128)).to.be.reverted;
-    expect(await safeMath.sub(Q128, Q128.sub(1))).to.be.eq(1);
+    await expect(safeMath.sub(Q128 - 1n, Q128)).to.be.reverted;
+    expect(await safeMath.sub(Q128, Q128 - 1n)).to.be.eq(1);
   });
 
   it('#mul', async () => {
@@ -33,35 +30,35 @@ describe('SafeMath', () => {
   });
 
   it('#addInt', async () => {
-    await expect(safeMath.addInt(BigNumber.from(2).pow(255).sub(1), 1)).to.be.reverted;
+    await expect(safeMath.addInt(2n ** 255n - 1n, 1)).to.be.reverted;
   });
 
   it('#subInt', async () => {
-    await expect(safeMath.subInt(100, BigNumber.from(2).pow(255).sub(1).mul(-1))).to.be.reverted;
-    await expect(safeMath.subInt(BigNumber.from(2).pow(255).sub(1), -100)).to.be.reverted;
+    await expect(safeMath.subInt(100, (2n ** 255n - 1n) * (-1n))).to.be.reverted;
+    await expect(safeMath.subInt(2n ** 255n - 1n, -100)).to.be.reverted;
   });
 
   it('#add128', async () => {
-    await expect(safeMath.add128(Q128.sub(10), 15)).to.be.reverted;
+    await expect(safeMath.add128(Q128 - 10n, 15)).to.be.reverted;
     expect(await safeMath.add128(10, 10)).to.be.eq(20);
   });
 
   it('#toUint160', async () => {
-    await expect(safeMath.toUint160(BigNumber.from(2).pow(255).sub(1))).to.be.reverted;
+    await expect(safeMath.toUint160(2n ** 255n - 1n)).to.be.reverted;
   });
 
   it('#toUint128', async () => {
-    await expect(safeMath.toUint128(BigNumber.from(2).pow(255).sub(1))).to.be.reverted;
+    await expect(safeMath.toUint128(2n ** 255n - 1n)).to.be.reverted;
   });
 
   it('#toInt128', async () => {
-    await expect(safeMath.toInt128(BigNumber.from(2).pow(255).sub(1))).to.be.reverted;
-    expect(await safeMath.toInt128(BigNumber.from(2).pow(127).sub(1))).to.be.eq(BigNumber.from(2).pow(127).sub(1));
-    await expect(safeMath.toInt128U(BigNumber.from(2).pow(128).sub(1))).to.be.reverted;
+    await expect(safeMath.toInt128(2n ** 255n - 1n)).to.be.reverted;
+    expect(await safeMath.toInt128(2n ** 127n - 1n)).to.be.eq(2n ** 127n - 1n);
+    await expect(safeMath.toInt128U(2n ** 128n - 1n)).to.be.reverted;
   });
 
   it('#toInt256', async () => {
-    await expect(safeMath.toInt256(BigNumber.from(2).pow(256).sub(1))).to.be.reverted;
+    await expect(safeMath.toInt256(MaxUint256)).to.be.reverted;
   });
 });
 
@@ -69,7 +66,7 @@ describe('FullMath', () => {
   let fullMath: FullMathTest;
   before('deploy FullMathTest', async () => {
     const factory = await ethers.getContractFactory('FullMathTest');
-    fullMath = (await factory.deploy()) as FullMathTest;
+    fullMath = (await factory.deploy()) as any as FullMathTest;
   });
 
   describe('#mulDiv', () => {
@@ -83,7 +80,7 @@ describe('FullMath', () => {
       await expect(fullMath.mulDiv(Q128, Q128, 1)).to.be.reverted;
     });
     it('reverts on overflow with all max inputs', async () => {
-      await expect(fullMath.mulDiv(MaxUint256, MaxUint256, MaxUint256.sub(1))).to.be.reverted;
+      await expect(fullMath.mulDiv(MaxUint256, MaxUint256, MaxUint256 - 1n)).to.be.reverted;
     });
 
     it('all max inputs', async () => {
@@ -91,24 +88,24 @@ describe('FullMath', () => {
     });
 
     it('accurate without phantom overflow', async () => {
-      const result = Q128.div(3);
+      const result = Q128 / 3n;
       expect(
         await fullMath.mulDiv(
           Q128,
-          /**0.5=*/ BigNumber.from(50).mul(Q128).div(100),
-          /**1.5=*/ BigNumber.from(150).mul(Q128).div(100)
+          /**0.5=*/ 50n * Q128 / 100n,
+          /**1.5=*/ 150n * Q128 / 100n
         )
       ).to.eq(result);
     });
 
     it('accurate with phantom overflow', async () => {
-      const result = BigNumber.from(4375).mul(Q128).div(1000);
-      expect(await fullMath.mulDiv(Q128, BigNumber.from(35).mul(Q128), BigNumber.from(8).mul(Q128))).to.eq(result);
+      const result = 4375n * Q128 / 1000n;
+      expect(await fullMath.mulDiv(Q128, 35n * Q128, 8n * Q128)).to.eq(result);
     });
 
     it('accurate with phantom overflow and repeating decimal', async () => {
-      const result = BigNumber.from(1).mul(Q128).div(3);
-      expect(await fullMath.mulDiv(Q128, BigNumber.from(1000).mul(Q128), BigNumber.from(3000).mul(Q128))).to.eq(result);
+      const result = Q128 / 3n;
+      expect(await fullMath.mulDiv(Q128, 1000n * Q128, 3000n * Q128)).to.eq(result);
     });
   });
 
@@ -123,7 +120,7 @@ describe('FullMath', () => {
       await expect(fullMath.mulDivRoundingUp(Q128, Q128, 1)).to.be.reverted;
     });
     it('reverts on overflow with all max inputs', async () => {
-      await expect(fullMath.mulDivRoundingUp(MaxUint256, MaxUint256, MaxUint256.sub(1))).to.be.reverted;
+      await expect(fullMath.mulDivRoundingUp(MaxUint256, MaxUint256, MaxUint256 -1n)).to.be.reverted;
     });
 
     it('reverts if mulDiv overflows 256 bits after rounding up', async () => {
@@ -151,33 +148,33 @@ describe('FullMath', () => {
     });
 
     it('accurate without phantom overflow', async () => {
-      const result = Q128.div(3).add(1);
+      const result = Q128 / 3n + 1n;
       expect(
         await fullMath.mulDivRoundingUp(
           Q128,
-          /**0.5=*/ BigNumber.from(50).mul(Q128).div(100),
-          /**1.5=*/ BigNumber.from(150).mul(Q128).div(100)
+          /**0.5=*/ 50n * Q128 / 100n,
+          /**1.5=*/ 150n * Q128 / 100n
         )
       ).to.eq(result);
     });
 
     it('accurate with phantom overflow', async () => {
-      const result = BigNumber.from(4375).mul(Q128).div(1000);
-      expect(await fullMath.mulDivRoundingUp(Q128, BigNumber.from(35).mul(Q128), BigNumber.from(8).mul(Q128))).to.eq(
+      const result = 4375n * Q128 / 1000n;
+      expect(await fullMath.mulDivRoundingUp(Q128, 35n * Q128, 8n * Q128)).to.eq(
         result
       );
     });
 
     it('accurate with phantom overflow and repeating decimal', async () => {
-      const result = BigNumber.from(1).mul(Q128).div(3).add(1);
+      const result = Q128 / 3n + 1n;
       expect(
-        await fullMath.mulDivRoundingUp(Q128, BigNumber.from(1000).mul(Q128), BigNumber.from(3000).mul(Q128))
+        await fullMath.mulDivRoundingUp(Q128, 1000n * Q128, 3000n * Q128)
       ).to.eq(result);
     });
   });
 
   function pseudoRandomBigNumber() {
-    return BigNumber.from(new Decimal(MaxUint256.toString()).mul(Math.random().toString()).round().toString());
+    return BigInt(new Decimal(MaxUint256.toString()).mul(Math.random().toString()).round().toString());
   }
 
   // tiny fuzzer. unskip to run
@@ -206,25 +203,22 @@ describe('FullMath', () => {
 
     await Promise.all(
       tests.map(async ({ input: { x, y, d }, floored, ceiled }) => {
-        if (d.eq(0)) {
+        if (d == 0n) {
           await expect(floored).to.be.reverted;
           await expect(ceiled).to.be.reverted;
           return;
         }
 
-        if (x.eq(0) || y.eq(0)) {
-          await expect(floored).to.eq(0);
-          await expect(ceiled).to.eq(0);
-        } else if (x.mul(y).div(d).gt(MaxUint256)) {
+        if (x == 0n || y == 0n) {
+          expect(floored).to.eq(0);
+          expect(ceiled).to.eq(0);
+        } else if (x * y / d > MaxUint256) {
           await expect(floored).to.be.reverted;
           await expect(ceiled).to.be.reverted;
         } else {
-          expect(await floored).to.eq(x.mul(y).div(d));
+          expect(await floored).to.eq(x * y / d);
           expect(await ceiled).to.eq(
-            x
-              .mul(y)
-              .div(d)
-              .add(x.mul(y).mod(d).gt(0) ? 1 : 0)
+            x * y / d + (x * y % d > 0n ? 1n : 0n)
           );
         }
       })

--- a/src/core/test/PriceMovement.spec.ts
+++ b/src/core/test/PriceMovement.spec.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from 'ethers';
 import { ethers } from 'hardhat';
 import { expect } from './shared/expect';
 import snapshotGasCost from './shared/snapshotGasCost';
@@ -11,15 +10,15 @@ describe('PriceMovementMath', () => {
   before(async () => {
     const PriceMovementMathTestFactory = await ethers.getContractFactory('PriceMovementMathTest');
     const sqrtPriceMathTestFactory = await ethers.getContractFactory('TokenDeltaMathTest');
-    PriceMovementMath = (await PriceMovementMathTestFactory.deploy()) as PriceMovementMathTest;
-    sqrtPriceMath = (await sqrtPriceMathTestFactory.deploy()) as TokenDeltaMathTest;
+    PriceMovementMath = (await PriceMovementMathTestFactory.deploy()) as any as PriceMovementMathTest;
+    sqrtPriceMath = (await sqrtPriceMathTestFactory.deploy()) as any as TokenDeltaMathTest;
   });
 
   describe('#movePriceTowardsTarget', () => {
     it('revert cases', async () => {
       const price = encodePriceSqrt(1, 1);
       const priceTarget = encodePriceSqrt(101, 100);
-      const liquidity = BigNumber.from(2).pow(128).sub(1);
+      const liquidity = 2n ** 128n - 1n;
       const amount = expandTo18Decimals(1);
       const fee = 600;
 
@@ -44,7 +43,7 @@ describe('PriceMovementMath', () => {
     it('handles max liquidity', async () => {
       const price = encodePriceSqrt(1, 1);
       const priceTarget = encodePriceSqrt(101, 100);
-      const liquidity = BigNumber.from(2).pow(128).sub(1);
+      const liquidity = 2n ** 128n - 1n;
       const amount = expandTo18Decimals(1);
       const fee = 600;
 
@@ -59,15 +58,15 @@ describe('PriceMovementMath', () => {
       expect(amountIn).to.eq('999399998850334720');
       expect(feeAmount).to.eq('600001149665280');
       expect(amountOut).to.eq('999399998850334719');
-      expect(amountIn.add(feeAmount), 'entire amount is used').to.be.eq(amount);
+      expect(amountIn + feeAmount, 'entire amount is used').to.be.eq(amount);
       expect(sqrtQ).to.not.eq(priceTarget);
     });
 
     it('handles max liquidity and huge amount', async () => {
       const price = encodePriceSqrt(1, 1);
       const priceTarget = 1;
-      const liquidity = BigNumber.from(2).pow(128).sub(1);
-      const amount = BigNumber.from(2).pow(128).sub(1);
+      const liquidity = 2n ** 128n - 1n;
+      const amount = 2n ** 128n - 1n;
       const fee = 0;
 
       const { amountIn, amountOut, sqrtQ, feeAmount } = await PriceMovementMath.movePriceTowardsTarget(
@@ -81,14 +80,14 @@ describe('PriceMovementMath', () => {
       expect(amountIn).to.eq('340282366920938463463374607431768211455');
       expect(feeAmount).to.eq('0');
       expect(amountOut).to.eq('170141183460469231731687303715884105727');
-      expect(amountIn.add(feeAmount), 'entire amount is used').to.be.eq(amount);
+      expect(amountIn + feeAmount, 'entire amount is used').to.be.eq(amount);
       expect(sqrtQ).to.not.eq(priceTarget);
     });
 
     it('handles shifted liquidity internal overflow', async () => {
       const price = '1461446703485210103287273052203988822378723970342';
       const priceTarget = '4295128739';
-      const liquidity = BigNumber.from(2).pow(128).sub(1);
+      const liquidity = 2n ** 128n - 1n;
       const amount = '79231140595944432132633395119';
       const fee = 0;
 
@@ -103,15 +102,15 @@ describe('PriceMovementMath', () => {
       expect(amountIn).to.eq('79231140595944432132633395118');
       expect(feeAmount).to.eq('1');
       expect(amountOut).to.eq('6276865794854539910162679325510021897617750978755115584760');
-      expect(amountIn.add(feeAmount), 'entire amount is used').to.be.eq(amount);
+      expect(amountIn + feeAmount, 'entire amount is used').to.be.eq(amount);
       expect(sqrtQ).to.not.eq(priceTarget);
     });
 
     it('handles max liquidity and huge amount at max price', async () => {
       const price = '1461446703485210103287273052203988822378723970342';
       const priceTarget = '4295128739';
-      const liquidity = BigNumber.from(2).pow(128).sub(1);
-      const amount = BigNumber.from(2).pow(128).sub(1);
+      const liquidity = 2n ** 128n - 1n;
+      const amount = 2n ** 128n - 1n;
       const fee = 0;
 
       const { amountIn, amountOut, sqrtQ, feeAmount } = await PriceMovementMath.movePriceTowardsTarget(
@@ -125,7 +124,7 @@ describe('PriceMovementMath', () => {
       expect(amountIn).to.eq('340282366920938463463374607431203982080');
       expect(amountOut).to.eq('6276865796315986612967337485317294249402799158149117772694');
       expect(feeAmount).to.eq('564229375'); // TODO lost precision
-      expect(amountIn.add(feeAmount), 'entire amount is used').to.be.eq(amount);
+      expect(amountIn + feeAmount, 'entire amount is used').to.be.eq(amount);
       expect(sqrtQ).to.not.eq(priceTarget);
     });
 
@@ -148,7 +147,7 @@ describe('PriceMovementMath', () => {
       expect(amountIn).to.eq('9975124224178055');
       expect(feeAmount).to.eq('5988667735148');
       expect(amountOut).to.eq('9925619580021728');
-      expect(amountIn.add(feeAmount), 'entire amount is not used').to.lt(amount);
+      expect(amountIn + feeAmount, 'entire amount is not used').to.lt(amount);
 
       const priceAfterWholeInputAmount = await sqrtPriceMath.getNewPriceAfterInput(price, liquidity, amount, zeroToOne);
 
@@ -160,7 +159,7 @@ describe('PriceMovementMath', () => {
       const price = encodePriceSqrt(1, 1);
       const priceTarget = encodePriceSqrt(101, 100);
       const liquidity = expandTo18Decimals(2);
-      const amount = expandTo18Decimals(1).mul(-1);
+      const amount = expandTo18Decimals(1) * (-1n);
       const fee = 600;
       const zeroToOne = false;
 
@@ -175,12 +174,12 @@ describe('PriceMovementMath', () => {
       expect(amountIn).to.eq('9975124224178055');
       expect(feeAmount).to.eq('5988667735148');
       expect(amountOut).to.eq('9925619580021728');
-      expect(amountOut, 'entire amount out is not returned').to.lt(amount.mul(-1));
+      expect(amountOut, 'entire amount out is not returned').to.lt(amount* (-1n));
 
       const priceAfterWholeOutputAmount = await sqrtPriceMath.getNewPriceAfterOutput(
         price,
         liquidity,
-        amount.mul(-1),
+        amount * (-1n),
         zeroToOne
       );
 
@@ -207,12 +206,12 @@ describe('PriceMovementMath', () => {
       expect(amountIn).to.eq('999400000000000000');
       expect(feeAmount).to.eq('600000000000000');
       expect(amountOut).to.eq('666399946655997866');
-      expect(amountIn.add(feeAmount), 'entire amount is used').to.eq(amount);
+      expect(amountIn + feeAmount, 'entire amount is used').to.eq(amount);
 
       const priceAfterWholeInputAmountLessFee = await sqrtPriceMath.getNewPriceAfterInput(
         price,
         liquidity,
-        amount.sub(feeAmount),
+        amount - feeAmount,
         zeroToOne
       );
 
@@ -224,7 +223,7 @@ describe('PriceMovementMath', () => {
       const price = encodePriceSqrt(1, 1);
       const priceTarget = encodePriceSqrt(10000, 100);
       const liquidity = expandTo18Decimals(2);
-      const amount = expandTo18Decimals(1).mul(-1);
+      const amount = expandTo18Decimals(1) *(-1n);
       const fee = 600;
       const zeroToOne = false;
 
@@ -238,12 +237,12 @@ describe('PriceMovementMath', () => {
 
       expect(amountIn).to.eq('2000000000000000000');
       expect(feeAmount).to.eq('1200720432259356');
-      expect(amountOut).to.eq(amount.mul(-1));
+      expect(amountOut).to.eq(amount* (-1n));
 
       const priceAfterWholeOutputAmount = await sqrtPriceMath.getNewPriceAfterOutput(
         price,
         liquidity,
-        amount.mul(-1),
+        amount* (-1n),
         zeroToOne
       );
 
@@ -274,8 +273,8 @@ describe('PriceMovementMath', () => {
 
     it('amount out is capped at the desired amount out', async () => {
       const { amountIn, amountOut, sqrtQ, feeAmount } = await PriceMovementMath.movePriceTowardsTarget(
-        BigNumber.from('417332158212080721273783715441582'),
-        BigNumber.from('1452870262520218020823638996'),
+        BigInt('417332158212080721273783715441582'),
+        BigInt('1452870262520218020823638996'),
         '159344665391607089467575320103',
         '-1',
         1
@@ -288,15 +287,15 @@ describe('PriceMovementMath', () => {
 
     it('target price of 1 uses partial input amount', async () => {
       const { amountIn, amountOut, sqrtQ, feeAmount } = await PriceMovementMath.movePriceTowardsTarget(
-        BigNumber.from('2'),
-        BigNumber.from('1'),
+        BigInt('2'),
+        BigInt('1'),
         '1',
         '3915081100057732413702495386755767',
         1
       );
       expect(amountIn).to.eq('39614081257132168796771975168');
       expect(feeAmount).to.eq('39614120871253040049813');
-      expect(amountIn.add(feeAmount)).to.be.lte('3915081100057732413702495386755767');
+      expect(amountIn + feeAmount).to.be.lte('3915081100057732413702495386755767');
       expect(amountOut).to.eq('0');
       expect(sqrtQ).to.eq('1');
     });
@@ -316,8 +315,8 @@ describe('PriceMovementMath', () => {
     });
 
     it('handles intermediate insufficient liquidity in zero for one exact output case', async () => {
-      const sqrtP = BigNumber.from('20282409603651670423947251286016');
-      const sqrtPTarget = sqrtP.mul(11).div(10);
+      const sqrtP = BigInt('20282409603651670423947251286016');
+      const sqrtPTarget = sqrtP * 11n / 10n;
       const liquidity = 1024;
       // virtual reserves of one are only 4
       // https://www.wolframalpha.com/input/?i=1024+%2F+%2820282409603651670423947251286016+%2F+2**96%29
@@ -337,8 +336,8 @@ describe('PriceMovementMath', () => {
     });
 
     it('handles intermediate insufficient liquidity in one for zero exact output case', async () => {
-      const sqrtP = BigNumber.from('20282409603651670423947251286016');
-      const sqrtPTarget = sqrtP.mul(9).div(10);
+      const sqrtP = BigInt('20282409603651670423947251286016');
+      const sqrtPTarget = sqrtP * 9n / 10n;
       const liquidity = 1024;
       // virtual reserves of zero are only 262144
       // https://www.wolframalpha.com/input/?i=1024+*+%2820282409603651670423947251286016+%2F+2**96%29
@@ -386,7 +385,7 @@ describe('PriceMovementMath', () => {
             encodePriceSqrt(1, 1),
             encodePriceSqrt(101, 100),
             expandTo18Decimals(2),
-            expandTo18Decimals(1).mul(-1),
+            expandTo18Decimals(1)* (-1n),
             600
           )
         );
@@ -397,7 +396,7 @@ describe('PriceMovementMath', () => {
             encodePriceSqrt(1, 1),
             encodePriceSqrt(99, 100),
             expandTo18Decimals(2),
-            expandTo18Decimals(1).mul(-1),
+            expandTo18Decimals(1)* (-1n),
             600
           )
         );

--- a/src/core/test/TickMath.spec.ts
+++ b/src/core/test/TickMath.spec.ts
@@ -78,7 +78,7 @@ describe('TickMath', () => {
           it('result', async () => {
             expect((await tickMath.getSqrtRatioAtTick(tick)).toString()).to.matchSnapshot()
           })
-          it('gas', async () => {
+          it('gas [ @skip-on-coverage ]', async () => {
             await snapshotGasCost(tickMath.getGasCostOfGetSqrtRatioAtTick(tick))
           })
         })
@@ -156,7 +156,7 @@ describe('TickMath', () => {
         it('result', async () => {
           expect(Number(await tickMath.getTickAtSqrtRatio(ratio))).to.matchSnapshot()
         })
-        it('gas', async () => {
+        it('gas [ @skip-on-coverage ]', async () => {
           await snapshotGasCost(tickMath.getGasCostOfGetTickAtSqrtRatio(ratio))
         })
       })

--- a/src/core/test/__snapshots__/AlgebraPool.swaps.spec.ts.snap
+++ b/src/core/test/__snapshots__/AlgebraPool.swaps.spec.ts.snap
@@ -9,8 +9,8 @@ Object {
   "executionPrice": "0.0000",
   "poolPriceAfter": "0.99402",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -61,
-  "tickBefore": 0,
+  "tickAfter": -61n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -25,8 +25,8 @@ Object {
   "executionPrice": "0.99053",
   "poolPriceAfter": "0.99402",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -61,
-  "tickBefore": 0,
+  "tickAfter": -61n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -41,8 +41,8 @@ Object {
   "executionPrice": "1.0096",
   "poolPriceAfter": "1.0060",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 60,
-  "tickBefore": 0,
+  "tickAfter": 60n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195",
 }
@@ -57,8 +57,8 @@ Object {
   "executionPrice": "0.67319",
   "poolPriceAfter": "0.45866",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -7795,
-  "tickBefore": 0,
+  "tickAfter": -7795n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "484902372862337310435308815590269701",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -73,8 +73,8 @@ Object {
   "executionPrice": "1.4855",
   "poolPriceAfter": "2.1803",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 7794,
-  "tickBefore": 0,
+  "tickAfter": 7794n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "484902372862337310435308815590269701",
 }
@@ -89,8 +89,8 @@ Object {
   "executionPrice": "-Infinity",
   "poolPriceAfter": "1.0060",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 60,
-  "tickBefore": 0,
+  "tickAfter": 60n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -105,8 +105,8 @@ Object {
   "executionPrice": "0.99100",
   "poolPriceAfter": "0.99402",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -61,
-  "tickBefore": 0,
+  "tickAfter": -61n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -121,8 +121,8 @@ Object {
   "executionPrice": "1.0091",
   "poolPriceAfter": "1.0060",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 60,
-  "tickBefore": 0,
+  "tickAfter": 60n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195",
 }
@@ -137,8 +137,8 @@ Object {
   "executionPrice": "0.66201",
   "poolPriceAfter": "0.44355",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -8130,
-  "tickBefore": 0,
+  "tickAfter": -8130n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195061911147652317",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -153,8 +153,8 @@ Object {
   "executionPrice": "0.70287",
   "poolPriceAfter": "0.50000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -6932,
-  "tickBefore": 0,
+  "tickAfter": -6932n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "421044862698692740725170743495410672",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -169,8 +169,8 @@ Object {
   "executionPrice": "1.5105",
   "poolPriceAfter": "2.2545",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 8129,
-  "tickBefore": 0,
+  "tickAfter": 8129n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195061911147652317",
 }
@@ -185,8 +185,8 @@ Object {
   "executionPrice": "1.4227",
   "poolPriceAfter": "2.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 6931,
-  "tickBefore": 0,
+  "tickAfter": 6931n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "421044862698692740725170743495410672",
 }
@@ -201,8 +201,8 @@ Object {
   "executionPrice": "0.98912",
   "poolPriceAfter": "0.99402",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -61,
-  "tickBefore": 0,
+  "tickAfter": -61n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "680564733841876926926",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -217,8 +217,8 @@ Object {
   "executionPrice": "0.49403",
   "poolPriceAfter": "0.24701",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -13984,
-  "tickBefore": 0,
+  "tickAfter": -13984n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "1033184581225259164735720748018047287",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -233,8 +233,8 @@ Object {
   "executionPrice": "0.70287",
   "poolPriceAfter": "0.50000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -6932,
-  "tickBefore": 0,
+  "tickAfter": -6932n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "421044862698692740725170743495410672",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -246,7 +246,7 @@ Object {
   "poolBalance1": "1994009290088178439",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -259,8 +259,8 @@ Object {
   "executionPrice": "0.62867",
   "poolPriceAfter": "0.40000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -9164,
-  "tickBefore": 0,
+  "tickAfter": -9164n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "591962792073745646583043420635066071",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -272,7 +272,7 @@ Object {
   "poolBalance1": "1994009290088178439",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -285,8 +285,8 @@ Object {
   "executionPrice": "0.000000000000000000054028",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029543",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -887221,
-  "tickBefore": 0,
+  "tickAfter": -887221n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "18838218521532665617855486530458292400438092096504502406",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -301,8 +301,8 @@ Object {
   "executionPrice": "1.0110",
   "poolPriceAfter": "1.0060",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 60,
-  "tickBefore": 0,
+  "tickAfter": 60n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "680564733841876926926",
 }
@@ -317,8 +317,8 @@ Object {
   "executionPrice": "2.0242",
   "poolPriceAfter": "4.0484",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 13983,
-  "tickBefore": 0,
+  "tickAfter": 13983n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "1033184581225259164735720748018047287",
 }
@@ -333,8 +333,8 @@ Object {
   "executionPrice": "1.4227",
   "poolPriceAfter": "2.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 6931,
-  "tickBefore": 0,
+  "tickAfter": 6931n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "421044862698692740725170743495410672",
 }
@@ -346,7 +346,7 @@ Object {
   "poolBalance1": "1994009290088178439",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -359,8 +359,8 @@ Object {
   "executionPrice": "1.5907",
   "poolPriceAfter": "2.5000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 9163,
-  "tickBefore": 0,
+  "tickAfter": 9163n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "591962792073745646583043420635066071",
 }
@@ -372,7 +372,7 @@ Object {
   "poolBalance1": "1994009290088178439",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -385,8 +385,8 @@ Object {
   "executionPrice": "1.8509e+19",
   "poolPriceAfter": "3.3849e+38",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 887220,
-  "tickBefore": 0,
+  "tickAfter": 887220n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "18838218525064384187871093926663459720147685742572523601",
 }
@@ -401,8 +401,8 @@ Object {
   "executionPrice": "0.0000",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -417,8 +417,8 @@ Object {
   "executionPrice": "0.99579",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -433,8 +433,8 @@ Object {
   "executionPrice": "1.0042",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195",
 }
@@ -449,8 +449,8 @@ Object {
   "executionPrice": "0.67659",
   "poolPriceAfter": "0.46053",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -7755,
-  "tickBefore": 0,
+  "tickAfter": -7755n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "484902372862337310435308815590269701",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -465,8 +465,8 @@ Object {
   "executionPrice": "1.4780",
   "poolPriceAfter": "2.1714",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 7754,
-  "tickBefore": 0,
+  "tickAfter": 7754n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "484902372862337310435308815590269701",
 }
@@ -481,8 +481,8 @@ Object {
   "executionPrice": "-Infinity",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -497,8 +497,8 @@ Object {
   "executionPrice": "0.99600",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -513,8 +513,8 @@ Object {
   "executionPrice": "1.0040",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195",
 }
@@ -529,8 +529,8 @@ Object {
   "executionPrice": "0.66533",
   "poolPriceAfter": "0.44533",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -8090,
-  "tickBefore": 0,
+  "tickAfter": -8090n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195061911147652317",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -545,8 +545,8 @@ Object {
   "executionPrice": "0.70499",
   "poolPriceAfter": "0.50000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -6932,
-  "tickBefore": 0,
+  "tickAfter": -6932n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "424121077477644648929101317621422688",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -561,8 +561,8 @@ Object {
   "executionPrice": "1.5030",
   "poolPriceAfter": "2.2455",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 8089,
-  "tickBefore": 0,
+  "tickAfter": 8089n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195061911147652317",
 }
@@ -577,8 +577,8 @@ Object {
   "executionPrice": "1.4185",
   "poolPriceAfter": "2.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 6931,
-  "tickBefore": 0,
+  "tickAfter": 6931n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "424121077477644648929101317621422688",
 }
@@ -593,8 +593,8 @@ Object {
   "executionPrice": "0.99502",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "680564733841876926926",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -609,8 +609,8 @@ Object {
   "executionPrice": "0.49850",
   "poolPriceAfter": "0.25000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -13864,
-  "tickBefore": 0,
+  "tickAfter": -13864n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "1023918857334819954209013958517557896",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -625,8 +625,8 @@ Object {
   "executionPrice": "0.70499",
   "poolPriceAfter": "0.50000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -6932,
-  "tickBefore": 0,
+  "tickAfter": -6932n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "424121077477644648929101317621422688",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -638,7 +638,7 @@ Object {
   "poolBalance1": "2000000000000000000",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -651,8 +651,8 @@ Object {
   "executionPrice": "0.63056",
   "poolPriceAfter": "0.40000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -9164,
-  "tickBefore": 0,
+  "tickAfter": -9164n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "595039006852697554786973994761078087",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -664,7 +664,7 @@ Object {
   "poolBalance1": "2000000000000000000",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -677,8 +677,8 @@ Object {
   "executionPrice": "0.000000000000000000054190",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029543",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -887221,
-  "tickBefore": 0,
+  "tickAfter": -887221n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "18838218521532665617858562745237244308642022670630514423",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -693,8 +693,8 @@ Object {
   "executionPrice": "1.0050",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "680564733841876926926",
 }
@@ -709,8 +709,8 @@ Object {
   "executionPrice": "2.0060",
   "poolPriceAfter": "4.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 13863,
-  "tickBefore": 0,
+  "tickAfter": 13863n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "1023918857334819954209013958517557896",
 }
@@ -725,8 +725,8 @@ Object {
   "executionPrice": "1.4185",
   "poolPriceAfter": "2.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 6931,
-  "tickBefore": 0,
+  "tickAfter": 6931n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "424121077477644648929101317621422688",
 }
@@ -738,7 +738,7 @@ Object {
   "poolBalance1": "2000000000000000000",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -751,8 +751,8 @@ Object {
   "executionPrice": "1.5859",
   "poolPriceAfter": "2.5000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 9163,
-  "tickBefore": 0,
+  "tickAfter": 9163n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "595039006852697554786973994761078087",
 }
@@ -764,7 +764,7 @@ Object {
   "poolBalance1": "2000000000000000000",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -777,8 +777,8 @@ Object {
   "executionPrice": "1.8454e+19",
   "poolPriceAfter": "3.3849e+38",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 887220,
-  "tickBefore": 0,
+  "tickAfter": 887220n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "18838218525064384187874170141442411628351616316698535617",
 }
@@ -793,8 +793,8 @@ Object {
   "executionPrice": "0.0000",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -809,8 +809,8 @@ Object {
   "executionPrice": "0.99579",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -825,8 +825,8 @@ Object {
   "executionPrice": "1.0042",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195",
 }
@@ -841,8 +841,8 @@ Object {
   "executionPrice": "0.80394",
   "poolPriceAfter": "0.65216",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -4275,
-  "tickBefore": 0,
+  "tickAfter": -4275n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "243989293820644779460803155327372589",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -857,8 +857,8 @@ Object {
   "executionPrice": "1.2439",
   "poolPriceAfter": "1.5334",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 4274,
-  "tickBefore": 0,
+  "tickAfter": 4274n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "243989293820644779460803155327372589",
 }
@@ -873,8 +873,8 @@ Object {
   "executionPrice": "-Infinity",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -889,8 +889,8 @@ Object {
   "executionPrice": "0.99600",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -905,8 +905,8 @@ Object {
   "executionPrice": "1.0040",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195",
 }
@@ -921,8 +921,8 @@ Object {
   "executionPrice": "0.79593",
   "poolPriceAfter": "0.63923",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -4476,
-  "tickBefore": 0,
+  "tickAfter": -4476n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "256749882580179971840679703106063897",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -937,8 +937,8 @@ Object {
   "executionPrice": "0.79593",
   "poolPriceAfter": "0.63923",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -4476,
-  "tickBefore": 0,
+  "tickAfter": -4476n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "256749882580179971840679703106063897",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -953,8 +953,8 @@ Object {
   "executionPrice": "1.2564",
   "poolPriceAfter": "1.5644",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 4475,
-  "tickBefore": 0,
+  "tickAfter": 4475n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "256749882580179971840679703106063897",
 }
@@ -969,8 +969,8 @@ Object {
   "executionPrice": "1.2564",
   "poolPriceAfter": "1.5644",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 4475,
-  "tickBefore": 0,
+  "tickAfter": 4475n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "256749882580179971840679703106063897",
 }
@@ -985,8 +985,8 @@ Object {
   "executionPrice": "0.99502",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "680564733841876926926",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1001,8 +1001,8 @@ Object {
   "executionPrice": "0.74514",
   "poolPriceAfter": "0.56026",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -5794,
-  "tickBefore": 0,
+  "tickAfter": -5794n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "344037963272993171369654596359692757",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1017,8 +1017,8 @@ Object {
   "executionPrice": "0.74514",
   "poolPriceAfter": "0.56026",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -5794,
-  "tickBefore": 0,
+  "tickAfter": -5794n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "344037963272993171369654596359692757",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1030,7 +1030,7 @@ Object {
   "poolBalance1": "3994009290088178439",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -1043,8 +1043,8 @@ Object {
   "executionPrice": "0.62962",
   "poolPriceAfter": "0.40000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -9164,
-  "tickBefore": 0,
+  "tickAfter": -9164n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "595039006852697724928157455230309818",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1056,7 +1056,7 @@ Object {
   "poolBalance1": "3994009290088178439",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -1069,8 +1069,8 @@ Object {
   "executionPrice": "0.000000000000000000054109",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029543",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -887221,
-  "tickBefore": 0,
+  "tickAfter": -887221n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "18838218521532665617858562745237244478783206131099746153",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1085,8 +1085,8 @@ Object {
   "executionPrice": "1.0050",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "680564733841876926926",
 }
@@ -1101,8 +1101,8 @@ Object {
   "executionPrice": "1.3420",
   "poolPriceAfter": "1.7849",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 5793,
-  "tickBefore": 0,
+  "tickAfter": 5793n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "344037963272993171369654596359692757",
 }
@@ -1117,8 +1117,8 @@ Object {
   "executionPrice": "1.3420",
   "poolPriceAfter": "1.7849",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 5793,
-  "tickBefore": 0,
+  "tickAfter": 5793n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "344037963272993171369654596359692757",
 }
@@ -1130,7 +1130,7 @@ Object {
   "poolBalance1": "3994009290088178439",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -1143,8 +1143,8 @@ Object {
   "executionPrice": "1.5883",
   "poolPriceAfter": "2.5000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 9163,
-  "tickBefore": 0,
+  "tickAfter": 9163n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "595039006852697724928157455230309818",
 }
@@ -1156,7 +1156,7 @@ Object {
   "poolBalance1": "3994009290088178439",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -1169,8 +1169,8 @@ Object {
   "executionPrice": "1.8481e+19",
   "poolPriceAfter": "3.3849e+38",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 887220,
-  "tickBefore": 0,
+  "tickAfter": 887220n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "18838218525064384187874170141442411798492799777167767348",
 }
@@ -1185,8 +1185,8 @@ Object {
   "executionPrice": "0.0000",
   "poolPriceAfter": "0.10000",
   "poolPriceBefore": "0.10000",
-  "tickAfter": -23028,
-  "tickBefore": -23028,
+  "tickAfter": -23028n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1201,8 +1201,8 @@ Object {
   "executionPrice": "0.098947",
   "poolPriceAfter": "0.10000",
   "poolPriceBefore": "0.10000",
-  "tickAfter": -23028,
-  "tickBefore": -23028,
+  "tickAfter": -23028n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1217,8 +1217,8 @@ Object {
   "executionPrice": "0.10033",
   "poolPriceAfter": "0.10000",
   "poolPriceBefore": "0.10000",
-  "tickAfter": -23028,
-  "tickBefore": -23028,
+  "tickAfter": -23028n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195",
 }
@@ -1233,8 +1233,8 @@ Object {
   "executionPrice": "0.086714",
   "poolPriceAfter": "0.075646",
   "poolPriceBefore": "0.10000",
-  "tickAfter": -25819,
-  "tickBefore": -23028,
+  "tickAfter": -25819n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "484902372862337310435308815590269701",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1249,8 +1249,8 @@ Object {
   "executionPrice": "0.25051",
   "poolPriceAfter": "0.62379",
   "poolPriceBefore": "0.10000",
-  "tickAfter": -4720,
-  "tickBefore": -23028,
+  "tickAfter": -4720n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "484902372862337310435308815590269701",
 }
@@ -1265,8 +1265,8 @@ Object {
   "executionPrice": "-Infinity",
   "poolPriceAfter": "0.10000",
   "poolPriceBefore": "0.10000",
-  "tickAfter": -23028,
-  "tickBefore": -23028,
+  "tickAfter": -23028n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -1281,8 +1281,8 @@ Object {
   "executionPrice": "0.099000",
   "poolPriceAfter": "0.10000",
   "poolPriceBefore": "0.10000",
-  "tickAfter": -23028,
-  "tickBefore": -23028,
+  "tickAfter": -23028n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1297,8 +1297,8 @@ Object {
   "executionPrice": "0.10031",
   "poolPriceAfter": "0.10000",
   "poolPriceBefore": "0.10000",
-  "tickAfter": -23028,
-  "tickBefore": -23028,
+  "tickAfter": -23028n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195",
 }
@@ -1313,8 +1313,8 @@ Object {
   "executionPrice": "0.086124",
   "poolPriceAfter": "0.074620",
   "poolPriceBefore": "0.10000",
-  "tickAfter": -25955,
-  "tickBefore": -23028,
+  "tickAfter": -25955n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195061911147652317",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1326,7 +1326,7 @@ Object {
   "poolBalance1": "632455532033675867",
   "poolPriceBefore": "0.10000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -23028,
+  "tickBefore": -23028n,
 }
 `;
 
@@ -1339,8 +1339,8 @@ Object {
   "executionPrice": "0.25841",
   "poolPriceAfter": "0.66378",
   "poolPriceBefore": "0.10000",
-  "tickAfter": -4099,
-  "tickBefore": -23028,
+  "tickAfter": -4099n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195061911147652317",
 }
@@ -1355,8 +1355,8 @@ Object {
   "executionPrice": "0.25841",
   "poolPriceAfter": "0.66378",
   "poolPriceBefore": "0.10000",
-  "tickAfter": -4099,
-  "tickBefore": -23028,
+  "tickAfter": -4099n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195061911147652317",
 }
@@ -1371,8 +1371,8 @@ Object {
   "executionPrice": "0.099681",
   "poolPriceAfter": "0.10000",
   "poolPriceBefore": "0.10000",
-  "tickAfter": -23028,
-  "tickBefore": -23028,
+  "tickAfter": -23028n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "5274376687274546183682",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1387,8 +1387,8 @@ Object {
   "executionPrice": "0.000000000000000000017136",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029390",
   "poolPriceBefore": "0.10000",
-  "tickAfter": -887272,
-  "tickBefore": -23028,
+  "tickAfter": -887272n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "18838218521532665615644565874197029415000244183060032083",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1400,7 +1400,7 @@ Object {
   "poolBalance1": "632455532033675867",
   "poolPriceBefore": "0.10000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -23028,
+  "tickBefore": -23028n,
 }
 `;
 
@@ -1410,7 +1410,7 @@ Object {
   "poolBalance1": "632455532033675867",
   "poolPriceBefore": "0.10000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -23028,
+  "tickBefore": -23028n,
 }
 `;
 
@@ -1420,7 +1420,7 @@ Object {
   "poolBalance1": "632455532033675867",
   "poolPriceBefore": "0.10000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -23028,
+  "tickBefore": -23028n,
 }
 `;
 
@@ -1430,7 +1430,7 @@ Object {
   "poolBalance1": "632455532033675867",
   "poolPriceBefore": "0.10000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -23028,
+  "tickBefore": -23028n,
 }
 `;
 
@@ -1443,8 +1443,8 @@ Object {
   "executionPrice": "0.000000000000000000017136",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029543",
   "poolPriceBefore": "0.10000",
-  "tickAfter": -887221,
-  "tickBefore": -23028,
+  "tickAfter": -887221n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "18838218521532665615644565874197029415000244183060032083",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1459,8 +1459,8 @@ Object {
   "executionPrice": "0.10200",
   "poolPriceAfter": "0.10000",
   "poolPriceBefore": "0.10000",
-  "tickAfter": -23028,
-  "tickBefore": -23028,
+  "tickAfter": -23028n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -1475,8 +1475,8 @@ Object {
   "executionPrice": "0.11914",
   "poolPriceAfter": "0.14109",
   "poolPriceBefore": "0.10000",
-  "tickAfter": -19585,
-  "tickBefore": -23028,
+  "tickAfter": -19585n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "60811007371978153949466126675899993",
 }
@@ -1491,8 +1491,8 @@ Object {
   "executionPrice": "0.11914",
   "poolPriceAfter": "0.14109",
   "poolPriceBefore": "0.10000",
-  "tickAfter": -19585,
-  "tickBefore": -23028,
+  "tickAfter": -19585n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "60811007371978153949466126675899993",
 }
@@ -1507,8 +1507,8 @@ Object {
   "executionPrice": "0.20060",
   "poolPriceAfter": "0.40000",
   "poolPriceBefore": "0.10000",
-  "tickAfter": -9164,
-  "tickBefore": -23028,
+  "tickAfter": -9164n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "323791572837503501799197590655727196",
 }
@@ -1523,8 +1523,8 @@ Object {
   "executionPrice": "0.50150",
   "poolPriceAfter": "2.5000",
   "poolPriceBefore": "0.10000",
-  "tickAfter": 9163,
-  "tickBefore": -23028,
+  "tickAfter": 9163n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "1295166291350014007196790362622908787",
 }
@@ -1536,7 +1536,7 @@ Object {
   "poolBalance1": "632455532033675867",
   "poolPriceBefore": "0.10000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -23028,
+  "tickBefore": -23028n,
 }
 `;
 
@@ -1549,8 +1549,8 @@ Object {
   "executionPrice": "5.8355e+18",
   "poolPriceAfter": "3.3849e+38",
   "poolPriceBefore": "0.10000",
-  "tickAfter": 887220,
-  "tickBefore": -23028,
+  "tickAfter": 887220n,
+  "tickBefore": -23028n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "18838218525064384188574297425939728080761432684560366317",
 }
@@ -1565,8 +1565,8 @@ Object {
   "executionPrice": "0.0000",
   "poolPriceAfter": "10.000",
   "poolPriceBefore": "10.000",
-  "tickAfter": 23027,
-  "tickBefore": 23027,
+  "tickAfter": 23027n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1581,8 +1581,8 @@ Object {
   "executionPrice": "9.9674",
   "poolPriceAfter": "10.000",
   "poolPriceBefore": "10.000",
-  "tickAfter": 23027,
-  "tickBefore": 23027,
+  "tickAfter": 23027n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1597,8 +1597,8 @@ Object {
   "executionPrice": "10.106",
   "poolPriceAfter": "10.000",
   "poolPriceBefore": "10.000",
-  "tickAfter": 23027,
-  "tickBefore": 23027,
+  "tickAfter": 23027n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195",
 }
@@ -1613,8 +1613,8 @@ Object {
   "executionPrice": "3.9919",
   "poolPriceAfter": "1.6031",
   "poolPriceBefore": "10.000",
-  "tickAfter": 4719,
-  "tickBefore": 23027,
+  "tickAfter": 4719n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "484902372862337310435308815590269701",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1629,8 +1629,8 @@ Object {
   "executionPrice": "11.532",
   "poolPriceAfter": "13.219",
   "poolPriceBefore": "10.000",
-  "tickAfter": 25818,
-  "tickBefore": 23027,
+  "tickAfter": 25818n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "484902372862337310435308815590269701",
 }
@@ -1645,8 +1645,8 @@ Object {
   "executionPrice": "-Infinity",
   "poolPriceAfter": "10.000",
   "poolPriceBefore": "10.000",
-  "tickAfter": 23027,
-  "tickBefore": 23027,
+  "tickAfter": 23027n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -1661,8 +1661,8 @@ Object {
   "executionPrice": "9.9690",
   "poolPriceAfter": "10.000",
   "poolPriceBefore": "10.000",
-  "tickAfter": 23027,
-  "tickBefore": 23027,
+  "tickAfter": 23027n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1677,8 +1677,8 @@ Object {
   "executionPrice": "10.101",
   "poolPriceAfter": "10.000",
   "poolPriceBefore": "10.000",
-  "tickAfter": 23027,
-  "tickBefore": 23027,
+  "tickAfter": 23027n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195",
 }
@@ -1693,8 +1693,8 @@ Object {
   "executionPrice": "3.8697",
   "poolPriceAfter": "1.5065",
   "poolPriceBefore": "10.000",
-  "tickAfter": 4098,
-  "tickBefore": 23027,
+  "tickAfter": 4098n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195061911147652317",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1709,8 +1709,8 @@ Object {
   "executionPrice": "3.8697",
   "poolPriceAfter": "1.5065",
   "poolPriceBefore": "10.000",
-  "tickAfter": 4098,
-  "tickBefore": 23027,
+  "tickAfter": 4098n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195061911147652317",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1725,8 +1725,8 @@ Object {
   "executionPrice": "11.611",
   "poolPriceAfter": "13.401",
   "poolPriceBefore": "10.000",
-  "tickAfter": 25954,
-  "tickBefore": 23027,
+  "tickAfter": 25954n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195061911147652317",
 }
@@ -1738,7 +1738,7 @@ Object {
   "poolBalance1": "6324555320336758664",
   "poolPriceBefore": "10.000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 23027,
+  "tickBefore": 23027n,
 }
 `;
 
@@ -1751,8 +1751,8 @@ Object {
   "executionPrice": "9.8039",
   "poolPriceAfter": "10.000",
   "poolPriceBefore": "10.000",
-  "tickAfter": 23027,
-  "tickBefore": 23027,
+  "tickAfter": 23027n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1767,8 +1767,8 @@ Object {
   "executionPrice": "8.3936",
   "poolPriceAfter": "7.0877",
   "poolPriceBefore": "10.000",
-  "tickAfter": 19584,
-  "tickBefore": 23027,
+  "tickAfter": 19584n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "60811007371978153949466126675899993",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1783,8 +1783,8 @@ Object {
   "executionPrice": "8.3936",
   "poolPriceAfter": "7.0877",
   "poolPriceBefore": "10.000",
-  "tickAfter": 19584,
-  "tickBefore": 23027,
+  "tickAfter": 19584n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "60811007371978153949466126675899993",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1796,7 +1796,7 @@ Object {
   "poolBalance1": "6324555320336758664",
   "poolPriceBefore": "10.000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 23027,
+  "tickBefore": 23027n,
 }
 `;
 
@@ -1809,8 +1809,8 @@ Object {
   "executionPrice": "1.9940",
   "poolPriceAfter": "0.40000",
   "poolPriceBefore": "10.000",
-  "tickAfter": -9164,
-  "tickBefore": 23027,
+  "tickAfter": -9164n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "1295166291350014007196790362622908787",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1825,8 +1825,8 @@ Object {
   "executionPrice": "4.9850",
   "poolPriceAfter": "2.5000",
   "poolPriceBefore": "10.000",
-  "tickAfter": 9163,
-  "tickBefore": 23027,
+  "tickAfter": 9163n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "323791572837503501799197590655727196",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1841,8 +1841,8 @@ Object {
   "executionPrice": "0.00000000000000000017136",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029543",
   "poolPriceBefore": "10.000",
-  "tickAfter": -887221,
-  "tickBefore": 23027,
+  "tickAfter": -887221n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "18838218521532665618558690029734560761051839038492345122",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1857,8 +1857,8 @@ Object {
   "executionPrice": "10.032",
   "poolPriceAfter": "10.000",
   "poolPriceBefore": "10.000",
-  "tickAfter": 23027,
-  "tickBefore": 23027,
+  "tickAfter": 23027n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "5274376687274546183682",
 }
@@ -1873,8 +1873,8 @@ Object {
   "executionPrice": "5.8355e+19",
   "poolPriceAfter": "3.4026e+38",
   "poolPriceBefore": "10.000",
-  "tickAfter": 887271,
-  "tickBefore": 23027,
+  "tickAfter": 887271n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "18838218525064384185660173270402196734709837829128053278",
 }
@@ -1886,7 +1886,7 @@ Object {
   "poolBalance1": "6324555320336758664",
   "poolPriceBefore": "10.000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 23027,
+  "tickBefore": 23027n,
 }
 `;
 
@@ -1896,7 +1896,7 @@ Object {
   "poolBalance1": "6324555320336758664",
   "poolPriceBefore": "10.000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 23027,
+  "tickBefore": 23027n,
 }
 `;
 
@@ -1906,7 +1906,7 @@ Object {
   "poolBalance1": "6324555320336758664",
   "poolPriceBefore": "10.000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 23027,
+  "tickBefore": 23027n,
 }
 `;
 
@@ -1916,7 +1916,7 @@ Object {
   "poolBalance1": "6324555320336758664",
   "poolPriceBefore": "10.000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 23027,
+  "tickBefore": 23027n,
 }
 `;
 
@@ -1929,8 +1929,8 @@ Object {
   "executionPrice": "5.8355e+19",
   "poolPriceAfter": "3.3849e+38",
   "poolPriceBefore": "10.000",
-  "tickAfter": 887220,
-  "tickBefore": 23027,
+  "tickAfter": 887220n,
+  "tickBefore": 23027n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "18838218525064384185660173270402196734709837829128053278",
 }
@@ -1945,8 +1945,8 @@ Object {
   "executionPrice": "0.0000",
   "poolPriceAfter": "1.7014e+38",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": 880340,
-  "tickBefore": 880340,
+  "tickAfter": 880340n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1961,8 +1961,8 @@ Object {
   "executionPrice": "2.7456e+34",
   "poolPriceAfter": "4.4588e+30",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": 705759,
-  "tickBefore": 880340,
+  "tickAfter": 705759n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -1977,8 +1977,8 @@ Object {
   "executionPrice": "-Infinity",
   "poolPriceAfter": "1.7014e+38",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": 880340,
-  "tickBefore": 880340,
+  "tickAfter": 880340n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195",
 }
@@ -1993,8 +1993,8 @@ Object {
   "executionPrice": "2.7461e+19",
   "poolPriceAfter": "4.4588",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": 14949,
-  "tickBefore": 880340,
+  "tickAfter": 14949n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "484902372862337310435308815590269701",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2009,8 +2009,8 @@ Object {
   "executionPrice": "-Infinity",
   "poolPriceAfter": "1.7014e+38",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": 880340,
-  "tickBefore": 880340,
+  "tickAfter": 880340n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "484902372862337310435308815590269701",
 }
@@ -2025,8 +2025,8 @@ Object {
   "executionPrice": "-Infinity",
   "poolPriceAfter": "1.7014e+38",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": 880340,
-  "tickBefore": 880340,
+  "tickAfter": 880340n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -2041,8 +2041,8 @@ Object {
   "executionPrice": "2.6084e+34",
   "poolPriceAfter": "4.0229e+30",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": 704730,
-  "tickBefore": 880340,
+  "tickAfter": 704730n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2057,8 +2057,8 @@ Object {
   "executionPrice": "-Infinity",
   "poolPriceAfter": "1.7014e+38",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": 880340,
-  "tickBefore": 880340,
+  "tickAfter": 880340n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195",
 }
@@ -2073,8 +2073,8 @@ Object {
   "executionPrice": "2.6088e+19",
   "poolPriceAfter": "4.0241",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": 13923,
-  "tickBefore": 880340,
+  "tickAfter": 13923n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195061911147652317",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2089,8 +2089,8 @@ Object {
   "executionPrice": "2.6088e+19",
   "poolPriceAfter": "4.0241",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": 13923,
-  "tickBefore": 880340,
+  "tickAfter": 13923n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195061911147652317",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2105,8 +2105,8 @@ Object {
   "executionPrice": "-Infinity",
   "poolPriceAfter": "1.7014e+38",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": 880340,
-  "tickBefore": 880340,
+  "tickAfter": 880340n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195061911147652317",
 }
@@ -2118,7 +2118,7 @@ Object {
   "poolBalance1": "26087635650665564424699143612505016738",
   "poolPriceBefore": "1.7014e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 880340,
+  "tickBefore": 880340n,
 }
 `;
 
@@ -2131,8 +2131,8 @@ Object {
   "executionPrice": "500.00",
   "poolPriceAfter": "1.7014e+38",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": 880340,
-  "tickBefore": 880340,
+  "tickAfter": 880340n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2147,8 +2147,8 @@ Object {
   "executionPrice": "5.0000e+17",
   "poolPriceAfter": "1.7014e+38",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": 880340,
-  "tickBefore": 880340,
+  "tickAfter": 880340n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2163,8 +2163,8 @@ Object {
   "executionPrice": "5.0000e+17",
   "poolPriceAfter": "1.7014e+38",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": 880340,
-  "tickBefore": 880340,
+  "tickAfter": 880340n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2176,7 +2176,7 @@ Object {
   "poolBalance1": "26087635650665564424699143612505016738",
   "poolPriceBefore": "1.7014e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 880340,
+  "tickBefore": 880340n,
 }
 `;
 
@@ -2189,8 +2189,8 @@ Object {
   "executionPrice": "8.2249e+18",
   "poolPriceAfter": "0.40000",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": -9164,
-  "tickBefore": 880340,
+  "tickAfter": -9164n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "1618957864187517508995987953278635983",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2205,8 +2205,8 @@ Object {
   "executionPrice": "2.0562e+19",
   "poolPriceAfter": "2.5000",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": 9163,
-  "tickBefore": 880340,
+  "tickAfter": 9163n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "647583145675007003598395181311454393",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2221,8 +2221,8 @@ Object {
   "executionPrice": "0.70685",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029543",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": -887221,
-  "tickBefore": 880340,
+  "tickAfter": -887221n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "18838218521532665618882481602572064262851036629148072319",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2237,8 +2237,8 @@ Object {
   "executionPrice": "-Infinity",
   "poolPriceAfter": "3.4026e+38",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": 887271,
-  "tickBefore": 880340,
+  "tickAfter": 887271n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "5482407482066087054477299856254072312542046383926535301",
 }
@@ -2253,8 +2253,8 @@ Object {
   "executionPrice": "-Infinity",
   "poolPriceAfter": "3.4026e+38",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": 887271,
-  "tickBefore": 880340,
+  "tickAfter": 887271n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "5482407482066087054477299856254072312542046383926535301",
 }
@@ -2266,7 +2266,7 @@ Object {
   "poolBalance1": "26087635650665564424699143612505016738",
   "poolPriceBefore": "1.7014e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 880340,
+  "tickBefore": 880340n,
 }
 `;
 
@@ -2276,7 +2276,7 @@ Object {
   "poolBalance1": "26087635650665564424699143612505016738",
   "poolPriceBefore": "1.7014e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 880340,
+  "tickBefore": 880340n,
 }
 `;
 
@@ -2286,7 +2286,7 @@ Object {
   "poolBalance1": "26087635650665564424699143612505016738",
   "poolPriceBefore": "1.7014e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 880340,
+  "tickBefore": 880340n,
 }
 `;
 
@@ -2296,7 +2296,7 @@ Object {
   "poolBalance1": "26087635650665564424699143612505016738",
   "poolPriceBefore": "1.7014e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 880340,
+  "tickBefore": 880340n,
 }
 `;
 
@@ -2309,8 +2309,8 @@ Object {
   "executionPrice": "-Infinity",
   "poolPriceAfter": "3.3849e+38",
   "poolPriceBefore": "1.7014e+38",
-  "tickAfter": 887220,
-  "tickBefore": 880340,
+  "tickAfter": 887220n,
+  "tickBefore": 880340n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "5482407482066087054477299856254072312542046383926535301",
 }
@@ -2325,8 +2325,8 @@ Object {
   "executionPrice": "0.0000",
   "poolPriceAfter": "0.0000000000000000000000000000000000000059000",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": -880303,
-  "tickBefore": -880303,
+  "tickAfter": -880303n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2341,8 +2341,8 @@ Object {
   "executionPrice": "0.0000",
   "poolPriceAfter": "0.0000000000000000000000000000000000000059000",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": -880303,
-  "tickBefore": -880303,
+  "tickAfter": -880303n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "161634124287445770145102",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2357,8 +2357,8 @@ Object {
   "executionPrice": "0.000000000000000000000000000000000036491",
   "poolPriceAfter": "0.00000000000000000000000000000022427",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": -705760,
-  "tickBefore": -880303,
+  "tickAfter": -705760n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195",
 }
@@ -2373,8 +2373,8 @@ Object {
   "executionPrice": "0.0000",
   "poolPriceAfter": "0.0000000000000000000000000000000000000059000",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": -880303,
-  "tickBefore": -880303,
+  "tickAfter": -880303n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "161634124287445770145102938530089900441",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2389,8 +2389,8 @@ Object {
   "executionPrice": "0.000000000000000000036485",
   "poolPriceAfter": "0.22427",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": -14950,
-  "tickBefore": -880303,
+  "tickAfter": -14950n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "484902372862337310435308815590269701",
 }
@@ -2405,8 +2405,8 @@ Object {
   "executionPrice": "-Infinity",
   "poolPriceAfter": "0.0000000000000000000000000000000000000059000",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": -880303,
-  "tickBefore": -880303,
+  "tickAfter": -880303n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -2421,8 +2421,8 @@ Object {
   "executionPrice": "0.0000",
   "poolPriceAfter": "0.0000000000000000000000000000000000000059000",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": -880303,
-  "tickBefore": -880303,
+  "tickAfter": -880303n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731687",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2437,8 +2437,8 @@ Object {
   "executionPrice": "0.000000000000000000000000000000000038412",
   "poolPriceAfter": "0.00000000000000000000000000000024858",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": -704731,
-  "tickBefore": -880303,
+  "tickAfter": -704731n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195",
 }
@@ -2453,8 +2453,8 @@ Object {
   "executionPrice": "0.0000",
   "poolPriceAfter": "0.0000000000000000000000000000000000000059000",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": -880303,
-  "tickBefore": -880303,
+  "tickAfter": -880303n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731687303715884105728",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2466,7 +2466,7 @@ Object {
   "poolBalance1": "1",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -880303,
+  "tickBefore": -880303n,
 }
 `;
 
@@ -2479,8 +2479,8 @@ Object {
   "executionPrice": "0.000000000000000000038406",
   "poolPriceAfter": "0.24850",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": -13924,
-  "tickBefore": -880303,
+  "tickAfter": -13924n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195061911147652317",
 }
@@ -2495,8 +2495,8 @@ Object {
   "executionPrice": "0.000000000000000000038406",
   "poolPriceAfter": "0.24850",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": -13924,
-  "tickBefore": -880303,
+  "tickAfter": -13924n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195061911147652317",
 }
@@ -2511,8 +2511,8 @@ Object {
   "executionPrice": "0.0000",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029390",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": -887272,
-  "tickBefore": -880303,
+  "tickAfter": -887272n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "5507930424444982259736347157352787128931407551935325049",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2527,8 +2527,8 @@ Object {
   "executionPrice": "0.0000",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029390",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": -887272,
-  "tickBefore": -880303,
+  "tickAfter": -887272n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "5507930424444982259736347157352787128931407551935325049",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2540,7 +2540,7 @@ Object {
   "poolBalance1": "1",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -880303,
+  "tickBefore": -880303n,
 }
 `;
 
@@ -2550,7 +2550,7 @@ Object {
   "poolBalance1": "1",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -880303,
+  "tickBefore": -880303n,
 }
 `;
 
@@ -2560,7 +2560,7 @@ Object {
   "poolBalance1": "1",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -880303,
+  "tickBefore": -880303n,
 }
 `;
 
@@ -2570,7 +2570,7 @@ Object {
   "poolBalance1": "1",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -880303,
+  "tickBefore": -880303n,
 }
 `;
 
@@ -2583,8 +2583,8 @@ Object {
   "executionPrice": "0.0000",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029543",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": -887221,
-  "tickBefore": -880303,
+  "tickAfter": -887221n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "5507930424444982259736347157352787128931407551935325049",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2599,8 +2599,8 @@ Object {
   "executionPrice": "0.0020000",
   "poolPriceAfter": "0.0000000000000000000000000000000000000059000",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": -880303,
-  "tickBefore": -880303,
+  "tickAfter": -880303n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -2615,8 +2615,8 @@ Object {
   "executionPrice": "0.0000000000000000020000",
   "poolPriceAfter": "0.0000000000000000000000000000000000000059000",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": -880303,
-  "tickBefore": -880303,
+  "tickAfter": -880303n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -2631,8 +2631,8 @@ Object {
   "executionPrice": "0.0000000000000000020000",
   "poolPriceAfter": "0.0000000000000000000000000000000000000059000",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": -880303,
-  "tickBefore": -880303,
+  "tickAfter": -880303n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -2647,8 +2647,8 @@ Object {
   "executionPrice": "0.000000000000000000048726",
   "poolPriceAfter": "0.40000",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": -9164,
-  "tickBefore": -880303,
+  "tickAfter": -9164n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "647583145675007003598395181311454393",
 }
@@ -2663,8 +2663,8 @@ Object {
   "executionPrice": "0.00000000000000000012182",
   "poolPriceAfter": "2.5000",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": 9163,
-  "tickBefore": -880303,
+  "tickAfter": 9163n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "1618957864187517508995987953278635983",
 }
@@ -2676,7 +2676,7 @@ Object {
   "poolBalance1": "1",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -880303,
+  "tickBefore": -880303n,
 }
 `;
 
@@ -2689,8 +2689,8 @@ Object {
   "executionPrice": "1.4174",
   "poolPriceAfter": "3.3849e+38",
   "poolPriceBefore": "0.0000000000000000000000000000000000000059000",
-  "tickAfter": 887220,
-  "tickBefore": -880303,
+  "tickAfter": 887220n,
+  "tickBefore": -880303n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "18838218525064384188898088998777231582560630275216093514",
 }
@@ -2705,8 +2705,8 @@ Object {
   "executionPrice": "0.0000",
   "poolPriceAfter": "3.3849e+38",
   "poolPriceBefore": "3.4026e+38",
-  "tickAfter": 887219,
-  "tickBefore": 887271,
+  "tickAfter": 887219n,
+  "tickBefore": 887271n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2721,8 +2721,8 @@ Object {
   "executionPrice": "3.8729e+34",
   "poolPriceAfter": "4.4592e+30",
   "poolPriceBefore": "3.4026e+38",
-  "tickAfter": 705760,
-  "tickBefore": 887271,
+  "tickAfter": 705760n,
+  "tickBefore": 887271n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2734,7 +2734,7 @@ Object {
   "poolBalance1": "36796311329002736532545403775337522448",
   "poolPriceBefore": "3.4026e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 887271,
+  "tickBefore": 887271n,
 }
 `;
 
@@ -2747,8 +2747,8 @@ Object {
   "executionPrice": "3.8733e+19",
   "poolPriceAfter": "4.4588",
   "poolPriceBefore": "3.4026e+38",
-  "tickAfter": 14949,
-  "tickBefore": 887271,
+  "tickAfter": 14949n,
+  "tickBefore": 887271n,
   "totalFeeGrowth0TokenDelta": "484902372862337310435308815590269701",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2760,7 +2760,7 @@ Object {
   "poolBalance1": "36796311329002736532545403775337522448",
   "poolPriceBefore": "3.4026e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 887271,
+  "tickBefore": 887271n,
 }
 `;
 
@@ -2770,7 +2770,7 @@ Object {
   "poolBalance1": "36796311329002736532545403775337522448",
   "poolPriceBefore": "3.4026e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 887271,
+  "tickBefore": 887271n,
 }
 `;
 
@@ -2783,8 +2783,8 @@ Object {
   "executionPrice": "3.6792e+34",
   "poolPriceAfter": "4.0232e+30",
   "poolPriceBefore": "3.4026e+38",
-  "tickAfter": 704731,
-  "tickBefore": 887271,
+  "tickAfter": 704731n,
+  "tickBefore": 887271n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2796,7 +2796,7 @@ Object {
   "poolBalance1": "36796311329002736532545403775337522448",
   "poolPriceBefore": "3.4026e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 887271,
+  "tickBefore": 887271n,
 }
 `;
 
@@ -2809,8 +2809,8 @@ Object {
   "executionPrice": "3.6796e+19",
   "poolPriceAfter": "4.0241",
   "poolPriceBefore": "3.4026e+38",
-  "tickAfter": 13923,
-  "tickBefore": 887271,
+  "tickAfter": 13923n,
+  "tickBefore": 887271n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195061911147652317",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2825,8 +2825,8 @@ Object {
   "executionPrice": "3.6796e+19",
   "poolPriceAfter": "4.0241",
   "poolPriceBefore": "3.4026e+38",
-  "tickAfter": 13923,
-  "tickBefore": 887271,
+  "tickAfter": 13923n,
+  "tickBefore": 887271n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195061911147652317",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2838,7 +2838,7 @@ Object {
   "poolBalance1": "36796311329002736532545403775337522448",
   "poolPriceBefore": "3.4026e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 887271,
+  "tickBefore": 887271n,
 }
 `;
 
@@ -2848,7 +2848,7 @@ Object {
   "poolBalance1": "36796311329002736532545403775337522448",
   "poolPriceBefore": "3.4026e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 887271,
+  "tickBefore": 887271n,
 }
 `;
 
@@ -2861,8 +2861,8 @@ Object {
   "executionPrice": "500.00",
   "poolPriceAfter": "3.3849e+38",
   "poolPriceBefore": "3.4026e+38",
-  "tickAfter": 887219,
-  "tickBefore": 887271,
+  "tickAfter": 887219n,
+  "tickBefore": 887271n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2877,8 +2877,8 @@ Object {
   "executionPrice": "5.0000e+17",
   "poolPriceAfter": "3.3849e+38",
   "poolPriceBefore": "3.4026e+38",
-  "tickAfter": 887219,
-  "tickBefore": 887271,
+  "tickAfter": 887219n,
+  "tickBefore": 887271n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2893,8 +2893,8 @@ Object {
   "executionPrice": "5.0000e+17",
   "poolPriceAfter": "3.3849e+38",
   "poolPriceBefore": "3.4026e+38",
-  "tickAfter": 887219,
-  "tickBefore": 887271,
+  "tickAfter": 887219n,
+  "tickBefore": 887271n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2906,7 +2906,7 @@ Object {
   "poolBalance1": "36796311329002736532545403775337522448",
   "poolPriceBefore": "3.4026e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 887271,
+  "tickBefore": 887271n,
 }
 `;
 
@@ -2919,8 +2919,8 @@ Object {
   "executionPrice": "1.1601e+19",
   "poolPriceAfter": "0.40000",
   "poolPriceBefore": "3.4026e+38",
-  "tickAfter": -9164,
-  "tickBefore": 887271,
+  "tickAfter": -9164n,
+  "tickBefore": 887271n,
   "totalFeeGrowth0TokenDelta": "1618957864187517508995987953278635983",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2935,8 +2935,8 @@ Object {
   "executionPrice": "2.9003e+19",
   "poolPriceAfter": "2.5000",
   "poolPriceBefore": "3.4026e+38",
-  "tickAfter": 9163,
-  "tickBefore": 887271,
+  "tickAfter": 9163n,
+  "tickBefore": 887271n,
   "totalFeeGrowth0TokenDelta": "647583145675007003598395181311454393",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2951,8 +2951,8 @@ Object {
   "executionPrice": "0.99700",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029543",
   "poolPriceBefore": "3.4026e+38",
-  "tickAfter": -887221,
-  "tickBefore": 887271,
+  "tickAfter": -887221n,
+  "tickBefore": 887271n,
   "totalFeeGrowth0TokenDelta": "18838218521532665618882481602572064262851036629148072319",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -2964,7 +2964,7 @@ Object {
   "poolBalance1": "36796311329002736532545403775337522448",
   "poolPriceBefore": "3.4026e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 887271,
+  "tickBefore": 887271n,
 }
 `;
 
@@ -2974,7 +2974,7 @@ Object {
   "poolBalance1": "36796311329002736532545403775337522448",
   "poolPriceBefore": "3.4026e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 887271,
+  "tickBefore": 887271n,
 }
 `;
 
@@ -2984,7 +2984,7 @@ Object {
   "poolBalance1": "36796311329002736532545403775337522448",
   "poolPriceBefore": "3.4026e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 887271,
+  "tickBefore": 887271n,
 }
 `;
 
@@ -2994,7 +2994,7 @@ Object {
   "poolBalance1": "36796311329002736532545403775337522448",
   "poolPriceBefore": "3.4026e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 887271,
+  "tickBefore": 887271n,
 }
 `;
 
@@ -3004,7 +3004,7 @@ Object {
   "poolBalance1": "36796311329002736532545403775337522448",
   "poolPriceBefore": "3.4026e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 887271,
+  "tickBefore": 887271n,
 }
 `;
 
@@ -3014,7 +3014,7 @@ Object {
   "poolBalance1": "36796311329002736532545403775337522448",
   "poolPriceBefore": "3.4026e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 887271,
+  "tickBefore": 887271n,
 }
 `;
 
@@ -3024,7 +3024,7 @@ Object {
   "poolBalance1": "36796311329002736532545403775337522448",
   "poolPriceBefore": "3.4026e+38",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 887271,
+  "tickBefore": 887271n,
 }
 `;
 
@@ -3034,7 +3034,7 @@ Object {
   "poolBalance1": "0",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -887272,
+  "tickBefore": -887272n,
 }
 `;
 
@@ -3044,7 +3044,7 @@ Object {
   "poolBalance1": "0",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -887272,
+  "tickBefore": -887272n,
 }
 `;
 
@@ -3057,8 +3057,8 @@ Object {
   "executionPrice": "0.000000000000000000000000000000000025821",
   "poolPriceAfter": "0.00000000000000000000000000000022425",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
-  "tickAfter": -705761,
-  "tickBefore": -887272,
+  "tickAfter": -705761n,
+  "tickBefore": -887272n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195",
 }
@@ -3070,7 +3070,7 @@ Object {
   "poolBalance1": "0",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -887272,
+  "tickBefore": -887272n,
 }
 `;
 
@@ -3083,8 +3083,8 @@ Object {
   "executionPrice": "0.000000000000000000025818",
   "poolPriceAfter": "0.22427",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
-  "tickAfter": -14950,
-  "tickBefore": -887272,
+  "tickAfter": -14950n,
+  "tickBefore": -887272n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "484902372862337310435308815590269701",
 }
@@ -3099,8 +3099,8 @@ Object {
   "executionPrice": "-Infinity",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029543",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
-  "tickAfter": -887220,
-  "tickBefore": -887272,
+  "tickAfter": -887220n,
+  "tickBefore": -887272n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -3112,7 +3112,7 @@ Object {
   "poolBalance1": "0",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -887272,
+  "tickBefore": -887272n,
 }
 `;
 
@@ -3125,8 +3125,8 @@ Object {
   "executionPrice": "0.000000000000000000000000000000000027180",
   "poolPriceAfter": "0.00000000000000000000000000000024856",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
-  "tickAfter": -704732,
-  "tickBefore": -887272,
+  "tickAfter": -704732n,
+  "tickBefore": -887272n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195",
 }
@@ -3138,7 +3138,7 @@ Object {
   "poolBalance1": "0",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -887272,
+  "tickBefore": -887272n,
 }
 `;
 
@@ -3148,7 +3148,7 @@ Object {
   "poolBalance1": "0",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -887272,
+  "tickBefore": -887272n,
 }
 `;
 
@@ -3161,8 +3161,8 @@ Object {
   "executionPrice": "0.000000000000000000027177",
   "poolPriceAfter": "0.24850",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
-  "tickAfter": -13924,
-  "tickBefore": -887272,
+  "tickAfter": -13924n,
+  "tickBefore": -887272n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195061911147652317",
 }
@@ -3177,8 +3177,8 @@ Object {
   "executionPrice": "0.000000000000000000027177",
   "poolPriceAfter": "0.24850",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
-  "tickAfter": -13924,
-  "tickBefore": -887272,
+  "tickAfter": -13924n,
+  "tickBefore": -887272n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195061911147652317",
 }
@@ -3190,7 +3190,7 @@ Object {
   "poolBalance1": "0",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -887272,
+  "tickBefore": -887272n,
 }
 `;
 
@@ -3200,7 +3200,7 @@ Object {
   "poolBalance1": "0",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -887272,
+  "tickBefore": -887272n,
 }
 `;
 
@@ -3210,7 +3210,7 @@ Object {
   "poolBalance1": "0",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -887272,
+  "tickBefore": -887272n,
 }
 `;
 
@@ -3220,7 +3220,7 @@ Object {
   "poolBalance1": "0",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -887272,
+  "tickBefore": -887272n,
 }
 `;
 
@@ -3230,7 +3230,7 @@ Object {
   "poolBalance1": "0",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -887272,
+  "tickBefore": -887272n,
 }
 `;
 
@@ -3240,7 +3240,7 @@ Object {
   "poolBalance1": "0",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -887272,
+  "tickBefore": -887272n,
 }
 `;
 
@@ -3250,7 +3250,7 @@ Object {
   "poolBalance1": "0",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -887272,
+  "tickBefore": -887272n,
 }
 `;
 
@@ -3263,8 +3263,8 @@ Object {
   "executionPrice": "0.0020000",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029543",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
-  "tickAfter": -887220,
-  "tickBefore": -887272,
+  "tickAfter": -887220n,
+  "tickBefore": -887272n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -3279,8 +3279,8 @@ Object {
   "executionPrice": "0.0000000000000000020000",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029543",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
-  "tickAfter": -887220,
-  "tickBefore": -887272,
+  "tickAfter": -887220n,
+  "tickBefore": -887272n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -3295,8 +3295,8 @@ Object {
   "executionPrice": "0.0000000000000000020000",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029543",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
-  "tickAfter": -887220,
-  "tickBefore": -887272,
+  "tickAfter": -887220n,
+  "tickBefore": -887272n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -3311,8 +3311,8 @@ Object {
   "executionPrice": "0.000000000000000000034479",
   "poolPriceAfter": "0.40000",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
-  "tickAfter": -9164,
-  "tickBefore": -887272,
+  "tickAfter": -9164n,
+  "tickBefore": -887272n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "647583145675007003598395181311454393",
 }
@@ -3327,8 +3327,8 @@ Object {
   "executionPrice": "0.000000000000000000086199",
   "poolPriceAfter": "2.5000",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
-  "tickAfter": 9163,
-  "tickBefore": -887272,
+  "tickAfter": 9163n,
+  "tickBefore": -887272n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "1618957864187517508995987953278635983",
 }
@@ -3340,7 +3340,7 @@ Object {
   "poolBalance1": "0",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": -887272,
+  "tickBefore": -887272n,
 }
 `;
 
@@ -3353,8 +3353,8 @@ Object {
   "executionPrice": "1.0030",
   "poolPriceAfter": "3.3849e+38",
   "poolPriceBefore": "0.0000000000000000000000000000000000000029390",
-  "tickAfter": 887220,
-  "tickBefore": -887272,
+  "tickAfter": 887220n,
+  "tickBefore": -887272n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "18838218525064384188898088998777231582560630275216093514",
 }
@@ -3369,8 +3369,8 @@ Object {
   "executionPrice": "0.0000",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3385,8 +3385,8 @@ Object {
   "executionPrice": "0.99789",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3401,8 +3401,8 @@ Object {
   "executionPrice": "1.0021",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -3417,8 +3417,8 @@ Object {
   "executionPrice": "0.99900",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029390",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -887272,
-  "tickBefore": 0,
+  "tickAfter": -887272n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "85130172636557991529041720559172",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3433,8 +3433,8 @@ Object {
   "executionPrice": "1.0010",
   "poolPriceAfter": "3.4026e+38",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 887271,
-  "tickBefore": 0,
+  "tickAfter": 887271n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "85130172636557991529041720559172",
 }
@@ -3449,8 +3449,8 @@ Object {
   "executionPrice": "-Infinity",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -3465,8 +3465,8 @@ Object {
   "executionPrice": "0.99800",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3481,8 +3481,8 @@ Object {
   "executionPrice": "1.0020",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -3497,8 +3497,8 @@ Object {
   "executionPrice": "0.99900",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029390",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -887272,
-  "tickBefore": 0,
+  "tickAfter": -887272n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "85130172636557991529041720559172",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3513,8 +3513,8 @@ Object {
   "executionPrice": "0.99900",
   "poolPriceAfter": "0.50000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -6932,
-  "tickBefore": 0,
+  "tickAfter": -6932n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "85130172636557991529041720559172",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3529,8 +3529,8 @@ Object {
   "executionPrice": "1.0010",
   "poolPriceAfter": "3.4026e+38",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 887271,
-  "tickBefore": 0,
+  "tickAfter": 887271n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "85130172636557991529041720559172",
 }
@@ -3545,8 +3545,8 @@ Object {
   "executionPrice": "1.0010",
   "poolPriceAfter": "2.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 6931,
-  "tickBefore": 0,
+  "tickAfter": 6931n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "85130172636557991529041720559172",
 }
@@ -3561,8 +3561,8 @@ Object {
   "executionPrice": "0.99800",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3577,8 +3577,8 @@ Object {
   "executionPrice": "0.99900",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029390",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -887272,
-  "tickBefore": 0,
+  "tickAfter": -887272n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "85130172636557991529041720559172",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3593,8 +3593,8 @@ Object {
   "executionPrice": "0.99900",
   "poolPriceAfter": "0.50000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -6932,
-  "tickBefore": 0,
+  "tickAfter": -6932n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "85130172636557991529041720559172",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3606,7 +3606,7 @@ Object {
   "poolBalance1": "999700069986003",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -3619,8 +3619,8 @@ Object {
   "executionPrice": "0.99900",
   "poolPriceAfter": "0.40000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -9164,
-  "tickBefore": 0,
+  "tickAfter": -9164n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "85130172636557991529041720559172",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3632,7 +3632,7 @@ Object {
   "poolBalance1": "999700069986003",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -3645,8 +3645,8 @@ Object {
   "executionPrice": "0.99900",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029543",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -887220,
-  "tickBefore": 0,
+  "tickAfter": -887220n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "85130172636557991529041720559172",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3661,8 +3661,8 @@ Object {
   "executionPrice": "1.0020",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -3677,8 +3677,8 @@ Object {
   "executionPrice": "1.0010",
   "poolPriceAfter": "3.4026e+38",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 887271,
-  "tickBefore": 0,
+  "tickAfter": 887271n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "85130172636557991529041720559172",
 }
@@ -3693,8 +3693,8 @@ Object {
   "executionPrice": "1.0010",
   "poolPriceAfter": "2.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 6931,
-  "tickBefore": 0,
+  "tickAfter": 6931n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "85130172636557991529041720559172",
 }
@@ -3706,7 +3706,7 @@ Object {
   "poolBalance1": "999700069986003",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -3719,8 +3719,8 @@ Object {
   "executionPrice": "1.0010",
   "poolPriceAfter": "2.5000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 9163,
-  "tickBefore": 0,
+  "tickAfter": 9163n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "85130172636557991529041720559172",
 }
@@ -3732,7 +3732,7 @@ Object {
   "poolBalance1": "999700069986003",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -3745,8 +3745,8 @@ Object {
   "executionPrice": "1.0010",
   "poolPriceAfter": "3.3849e+38",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 887220,
-  "tickBefore": 0,
+  "tickAfter": 887220n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "85130172636557991529041720559172",
 }
@@ -3761,8 +3761,8 @@ Object {
   "executionPrice": "0.0000",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "8388607",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3777,8 +3777,8 @@ Object {
   "executionPrice": "0.53895",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "3665821259",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3793,8 +3793,8 @@ Object {
   "executionPrice": "1.8555",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "3665821259",
 }
@@ -3809,8 +3809,8 @@ Object {
   "executionPrice": "0.99700",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "23907529950002868903594",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3825,8 +3825,8 @@ Object {
   "executionPrice": "1.0030",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "23907529950003699375687",
 }
@@ -3841,8 +3841,8 @@ Object {
   "executionPrice": "-Infinity",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "8388607",
 }
@@ -3857,8 +3857,8 @@ Object {
   "executionPrice": "0.51200",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "4085251609",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3873,8 +3873,8 @@ Object {
   "executionPrice": "1.9531",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "4085251609",
 }
@@ -3889,8 +3889,8 @@ Object {
   "executionPrice": "0.99700",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "25165821000001786773291",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3905,8 +3905,8 @@ Object {
   "executionPrice": "0.99700",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "25165821000001786773291",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3921,8 +3921,8 @@ Object {
   "executionPrice": "1.0030",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "25165821000001182793587",
 }
@@ -3937,8 +3937,8 @@ Object {
   "executionPrice": "1.0030",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "25165821000001182793587",
 }
@@ -3953,8 +3953,8 @@ Object {
   "executionPrice": "0.97182",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "33554428",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3969,8 +3969,8 @@ Object {
   "executionPrice": "0.99700",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "25241545636911368106849",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3985,8 +3985,8 @@ Object {
   "executionPrice": "0.99700",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "25241545636911368106849",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -3998,7 +3998,7 @@ Object {
   "poolBalance1": "40564824043007195765027393299788",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -4011,8 +4011,8 @@ Object {
   "executionPrice": "0.63056",
   "poolPriceAfter": "0.40000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -9164,
-  "tickBefore": 0,
+  "tickAfter": -9164n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "595039006852697512464428097925104891",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4024,7 +4024,7 @@ Object {
   "poolBalance1": "40564824043007195765027393299788",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -4034,7 +4034,7 @@ Object {
   "poolBalance1": "40564824043007195765027393299788",
   "poolPriceBefore": "1.0000",
   "swapError": "Transaction reverted without a reason string",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -4047,8 +4047,8 @@ Object {
   "executionPrice": "1.0290",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "33554428",
 }
@@ -4063,8 +4063,8 @@ Object {
   "executionPrice": "1.0030",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "25241545636911368106849",
 }
@@ -4079,8 +4079,8 @@ Object {
   "executionPrice": "1.0030",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "25241545636911368106849",
 }
@@ -4092,7 +4092,7 @@ Object {
   "poolBalance1": "40564824043007195765027393299788",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -4105,8 +4105,8 @@ Object {
   "executionPrice": "1.5859",
   "poolPriceAfter": "2.5000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 9163,
-  "tickBefore": 0,
+  "tickAfter": 9163n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "595039006852697512464428097891550463",
 }
@@ -4118,7 +4118,7 @@ Object {
   "poolBalance1": "40564824043007195765027393299788",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -4128,7 +4128,7 @@ Object {
   "poolBalance1": "40564824043007195765027393299788",
   "poolPriceBefore": "1.0000",
   "swapError": "Transaction reverted without a reason string",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -4141,8 +4141,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029390",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -887272,
-  "tickBefore": 0,
+  "tickAfter": -887272n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4157,8 +4157,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029390",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -887272,
-  "tickBefore": 0,
+  "tickAfter": -887272n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4173,8 +4173,8 @@ Object {
   "executionPrice": "1.0042",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195",
 }
@@ -4189,8 +4189,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029390",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -887272,
-  "tickBefore": 0,
+  "tickAfter": -887272n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4205,8 +4205,8 @@ Object {
   "executionPrice": "1.4780",
   "poolPriceAfter": "2.1714",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 7754,
-  "tickBefore": 0,
+  "tickAfter": 7754n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "484902372862337310435308815590269701",
 }
@@ -4221,8 +4221,8 @@ Object {
   "executionPrice": "-Infinity",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "170141183460469231731",
 }
@@ -4237,8 +4237,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029390",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -887272,
-  "tickBefore": 0,
+  "tickAfter": -887272n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4253,8 +4253,8 @@ Object {
   "executionPrice": "1.0040",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195",
 }
@@ -4269,8 +4269,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029390",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -887272,
-  "tickBefore": 0,
+  "tickAfter": -887272n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4285,8 +4285,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "0.50000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -6932,
-  "tickBefore": 0,
+  "tickAfter": -6932n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4301,8 +4301,8 @@ Object {
   "executionPrice": "1.5030",
   "poolPriceAfter": "2.2455",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 8089,
-  "tickBefore": 0,
+  "tickAfter": 8089n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "510423550381407695195061911147652317",
 }
@@ -4317,8 +4317,8 @@ Object {
   "executionPrice": "1.4185",
   "poolPriceAfter": "2.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 6931,
-  "tickBefore": 0,
+  "tickAfter": 6931n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "424121077477644648929101317621422688",
 }
@@ -4333,8 +4333,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029390",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -887272,
-  "tickBefore": 0,
+  "tickAfter": -887272n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4349,8 +4349,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029390",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -887272,
-  "tickBefore": 0,
+  "tickAfter": -887272n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4365,8 +4365,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "0.50000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -6932,
-  "tickBefore": 0,
+  "tickAfter": -6932n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4378,7 +4378,7 @@ Object {
   "poolBalance1": "0",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -4391,8 +4391,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "0.40000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -9164,
-  "tickBefore": 0,
+  "tickAfter": -9164n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4404,7 +4404,7 @@ Object {
   "poolBalance1": "0",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -4417,8 +4417,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029543",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -887220,
-  "tickBefore": 0,
+  "tickAfter": -887220n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4433,8 +4433,8 @@ Object {
   "executionPrice": "1.0050",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 0,
-  "tickBefore": 0,
+  "tickAfter": 0n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "680564733841876926926",
 }
@@ -4449,8 +4449,8 @@ Object {
   "executionPrice": "2.0060",
   "poolPriceAfter": "4.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 13863,
-  "tickBefore": 0,
+  "tickAfter": 13863n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "1023918857334819954209013958517557896",
 }
@@ -4465,8 +4465,8 @@ Object {
   "executionPrice": "1.4185",
   "poolPriceAfter": "2.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 6931,
-  "tickBefore": 0,
+  "tickAfter": 6931n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "424121077477644648929101317621422688",
 }
@@ -4478,7 +4478,7 @@ Object {
   "poolBalance1": "0",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -4491,8 +4491,8 @@ Object {
   "executionPrice": "1.5859",
   "poolPriceAfter": "2.5000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 9163,
-  "tickBefore": 0,
+  "tickAfter": 9163n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "595039006852697554786973994761078087",
 }
@@ -4504,7 +4504,7 @@ Object {
   "poolBalance1": "0",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -4517,8 +4517,8 @@ Object {
   "executionPrice": "404.52",
   "poolPriceAfter": "3.3849e+38",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 887220,
-  "tickBefore": 0,
+  "tickAfter": 887220n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "411930533732073409082078354252563077717",
 }
@@ -4533,8 +4533,8 @@ Object {
   "executionPrice": "0.0000",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "170141183460469231731",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4549,8 +4549,8 @@ Object {
   "executionPrice": "0.99579",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4565,8 +4565,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "3.4026e+38",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 887271,
-  "tickBefore": 0,
+  "tickAfter": 887271n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4581,8 +4581,8 @@ Object {
   "executionPrice": "0.67659",
   "poolPriceAfter": "0.46053",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -7755,
-  "tickBefore": 0,
+  "tickAfter": -7755n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "484902372862337310435308815590269701",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4597,8 +4597,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "3.4026e+38",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 887271,
-  "tickBefore": 0,
+  "tickAfter": 887271n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4613,8 +4613,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "3.4026e+38",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 887271,
-  "tickBefore": 0,
+  "tickAfter": 887271n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4629,8 +4629,8 @@ Object {
   "executionPrice": "0.99600",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4645,8 +4645,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "3.4026e+38",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 887271,
-  "tickBefore": 0,
+  "tickAfter": 887271n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4661,8 +4661,8 @@ Object {
   "executionPrice": "0.66533",
   "poolPriceAfter": "0.44533",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -8090,
-  "tickBefore": 0,
+  "tickAfter": -8090n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "510423550381407695195061911147652317",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4677,8 +4677,8 @@ Object {
   "executionPrice": "0.70499",
   "poolPriceAfter": "0.50000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -6932,
-  "tickBefore": 0,
+  "tickAfter": -6932n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "424121077477644648929101317621422688",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4693,8 +4693,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "3.4026e+38",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 887271,
-  "tickBefore": 0,
+  "tickAfter": 887271n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4709,8 +4709,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "2.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 6931,
-  "tickBefore": 0,
+  "tickAfter": 6931n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4725,8 +4725,8 @@ Object {
   "executionPrice": "0.99502",
   "poolPriceAfter": "1.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -1,
-  "tickBefore": 0,
+  "tickAfter": -1n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "680564733841876926926",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4741,8 +4741,8 @@ Object {
   "executionPrice": "0.49850",
   "poolPriceAfter": "0.25000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -13864,
-  "tickBefore": 0,
+  "tickAfter": -13864n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "1023918857334819954209013958517557896",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4757,8 +4757,8 @@ Object {
   "executionPrice": "0.70499",
   "poolPriceAfter": "0.50000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -6932,
-  "tickBefore": 0,
+  "tickAfter": -6932n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "424121077477644648929101317621422688",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4770,7 +4770,7 @@ Object {
   "poolBalance1": "1995041008271423675",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -4783,8 +4783,8 @@ Object {
   "executionPrice": "0.63056",
   "poolPriceAfter": "0.40000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -9164,
-  "tickBefore": 0,
+  "tickAfter": -9164n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "595039006852697554786973994761078087",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4796,7 +4796,7 @@ Object {
   "poolBalance1": "1995041008271423675",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -4809,8 +4809,8 @@ Object {
   "executionPrice": "0.0024721",
   "poolPriceAfter": "0.0000000000000000000000000000000000000029543",
   "poolPriceBefore": "1.0000",
-  "tickAfter": -887220,
-  "tickBefore": 0,
+  "tickAfter": -887220n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "411930533732073409082078354252563077717",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4825,8 +4825,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "3.4026e+38",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 887271,
-  "tickBefore": 0,
+  "tickAfter": 887271n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4841,8 +4841,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "3.4026e+38",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 887271,
-  "tickBefore": 0,
+  "tickAfter": 887271n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4857,8 +4857,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "2.0000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 6931,
-  "tickBefore": 0,
+  "tickAfter": 6931n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4870,7 +4870,7 @@ Object {
   "poolBalance1": "1995041008271423675",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -4883,8 +4883,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "2.5000",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 9163,
-  "tickBefore": 0,
+  "tickAfter": 9163n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }
@@ -4896,7 +4896,7 @@ Object {
   "poolBalance1": "1995041008271423675",
   "poolPriceBefore": "1.0000",
   "swapError": "VM Exception while processing transaction: reverted with custom error 'invalidLimitSqrtPrice()'",
-  "tickBefore": 0,
+  "tickBefore": 0n,
 }
 `;
 
@@ -4909,8 +4909,8 @@ Object {
   "executionPrice": "NaN",
   "poolPriceAfter": "3.3849e+38",
   "poolPriceBefore": "1.0000",
-  "tickAfter": 887220,
-  "tickBefore": 0,
+  "tickAfter": 887220n,
+  "tickBefore": 0n,
   "totalFeeGrowth0TokenDelta": "0",
   "totalFeeGrowth1TokenDelta": "0",
 }

--- a/src/core/test/__snapshots__/TickMath.spec.ts.snap
+++ b/src/core/test/__snapshots__/TickMath.spec.ts.snap
@@ -1,165 +1,165 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TickMath #getSqrtRatioAtTick tick -50 gas 1`] = `711`;
+exports[`TickMath #getSqrtRatioAtTick tick -50 gas [ @skip-on-coverage ] 1`] = `711`;
 
 exports[`TickMath #getSqrtRatioAtTick tick -50 result 1`] = `"79030349367926598376800521322"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick -100 gas 1`] = `711`;
+exports[`TickMath #getSqrtRatioAtTick tick -100 gas [ @skip-on-coverage ] 1`] = `711`;
 
 exports[`TickMath #getSqrtRatioAtTick tick -100 result 1`] = `"78833030112140176575862854579"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick -250 gas 1`] = `753`;
+exports[`TickMath #getSqrtRatioAtTick tick -250 gas [ @skip-on-coverage ] 1`] = `753`;
 
 exports[`TickMath #getSqrtRatioAtTick tick -250 result 1`] = `"78244023372248365697264290337"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick -500 gas 1`] = `753`;
+exports[`TickMath #getSqrtRatioAtTick tick -500 gas [ @skip-on-coverage ] 1`] = `753`;
 
 exports[`TickMath #getSqrtRatioAtTick tick -500 result 1`] = `"77272108795590369356373805297"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick -1000 gas 1`] = `753`;
+exports[`TickMath #getSqrtRatioAtTick tick -1000 gas [ @skip-on-coverage ] 1`] = `753`;
 
 exports[`TickMath #getSqrtRatioAtTick tick -1000 result 1`] = `"75364347830767020784054125655"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick -2500 gas 1`] = `739`;
+exports[`TickMath #getSqrtRatioAtTick tick -2500 gas [ @skip-on-coverage ] 1`] = `739`;
 
 exports[`TickMath #getSqrtRatioAtTick tick -2500 result 1`] = `"69919044979842180277688105136"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick -3000 gas 1`] = `767`;
+exports[`TickMath #getSqrtRatioAtTick tick -3000 gas [ @skip-on-coverage ] 1`] = `767`;
 
 exports[`TickMath #getSqrtRatioAtTick tick -3000 result 1`] = `"68192822843687888778582228483"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick -4000 gas 1`] = `753`;
+exports[`TickMath #getSqrtRatioAtTick tick -4000 gas [ @skip-on-coverage ] 1`] = `753`;
 
 exports[`TickMath #getSqrtRatioAtTick tick -4000 result 1`] = `"64867181785621769311890333195"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick -5000 gas 1`] = `739`;
+exports[`TickMath #getSqrtRatioAtTick tick -5000 gas [ @skip-on-coverage ] 1`] = `739`;
 
 exports[`TickMath #getSqrtRatioAtTick tick -5000 result 1`] = `"61703726247759831737814779831"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick -50000 gas 1`] = `753`;
+exports[`TickMath #getSqrtRatioAtTick tick -50000 gas [ @skip-on-coverage ] 1`] = `753`;
 
 exports[`TickMath #getSqrtRatioAtTick tick -50000 result 1`] = `"6504256538020985011912221507"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick -150000 gas 1`] = `781`;
+exports[`TickMath #getSqrtRatioAtTick tick -150000 gas [ @skip-on-coverage ] 1`] = `781`;
 
 exports[`TickMath #getSqrtRatioAtTick tick -150000 result 1`] = `"43836292794701720435367485"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick -250000 gas 1`] = `767`;
+exports[`TickMath #getSqrtRatioAtTick tick -250000 gas [ @skip-on-coverage ] 1`] = `767`;
 
 exports[`TickMath #getSqrtRatioAtTick tick -250000 result 1`] = `"295440463448801648376846"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick -500000 gas 1`] = `818`;
+exports[`TickMath #getSqrtRatioAtTick tick -500000 gas [ @skip-on-coverage ] 1`] = `818`;
 
 exports[`TickMath #getSqrtRatioAtTick tick -500000 result 1`] = `"1101692437043807371"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick -738203 gas 1`] = `865`;
+exports[`TickMath #getSqrtRatioAtTick tick -738203 gas [ @skip-on-coverage ] 1`] = `865`;
 
 exports[`TickMath #getSqrtRatioAtTick tick -738203 result 1`] = `"7409801140451"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 50 gas 1`] = `722`;
+exports[`TickMath #getSqrtRatioAtTick tick 50 gas [ @skip-on-coverage ] 1`] = `722`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 50 result 1`] = `"79426470787362580746886972461"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 100 gas 1`] = `722`;
+exports[`TickMath #getSqrtRatioAtTick tick 100 gas [ @skip-on-coverage ] 1`] = `722`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 100 result 1`] = `"79625275426524748796330556128"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 250 gas 1`] = `764`;
+exports[`TickMath #getSqrtRatioAtTick tick 250 gas [ @skip-on-coverage ] 1`] = `764`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 250 result 1`] = `"80224679980005306637834519095"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 500 gas 1`] = `764`;
+exports[`TickMath #getSqrtRatioAtTick tick 500 gas [ @skip-on-coverage ] 1`] = `764`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 500 result 1`] = `"81233731461783161732293370115"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 1000 gas 1`] = `764`;
+exports[`TickMath #getSqrtRatioAtTick tick 1000 gas [ @skip-on-coverage ] 1`] = `764`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 1000 result 1`] = `"83290069058676223003182343270"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 2500 gas 1`] = `750`;
+exports[`TickMath #getSqrtRatioAtTick tick 2500 gas [ @skip-on-coverage ] 1`] = `750`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 2500 result 1`] = `"89776708723587163891445672585"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 3000 gas 1`] = `778`;
+exports[`TickMath #getSqrtRatioAtTick tick 3000 gas [ @skip-on-coverage ] 1`] = `778`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 3000 result 1`] = `"92049301871182272007977902845"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 4000 gas 1`] = `764`;
+exports[`TickMath #getSqrtRatioAtTick tick 4000 gas [ @skip-on-coverage ] 1`] = `764`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 4000 result 1`] = `"96768528593268422080558758223"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 5000 gas 1`] = `750`;
+exports[`TickMath #getSqrtRatioAtTick tick 5000 gas [ @skip-on-coverage ] 1`] = `750`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 5000 result 1`] = `"101729702841318637793976746270"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 50000 gas 1`] = `764`;
+exports[`TickMath #getSqrtRatioAtTick tick 50000 gas [ @skip-on-coverage ] 1`] = `764`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 50000 result 1`] = `"965075977353221155028623082916"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 150000 gas 1`] = `792`;
+exports[`TickMath #getSqrtRatioAtTick tick 150000 gas [ @skip-on-coverage ] 1`] = `792`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 150000 result 1`] = `"143194173941309278083010301478497"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 250000 gas 1`] = `778`;
+exports[`TickMath #getSqrtRatioAtTick tick 250000 gas [ @skip-on-coverage ] 1`] = `778`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 250000 result 1`] = `"21246587762933397357449903968194344"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 500000 gas 1`] = `829`;
+exports[`TickMath #getSqrtRatioAtTick tick 500000 gas [ @skip-on-coverage ] 1`] = `829`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 500000 result 1`] = `"5697689776495288729098254600827762987878"`;
 
-exports[`TickMath #getSqrtRatioAtTick tick 738203 gas 1`] = `876`;
+exports[`TickMath #getSqrtRatioAtTick tick 738203 gas [ @skip-on-coverage ] 1`] = `876`;
 
 exports[`TickMath #getSqrtRatioAtTick tick 738203 result 1`] = `"847134979253254120489401328389043031315994541"`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 4295128739 gas 1`] = `2310`;
+exports[`TickMath #getTickAtSqrtRatio ratio 4295128739 gas [ @skip-on-coverage ] 1`] = `2310`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 4295128739 result 1`] = `-887272`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543 gas 1`] = `2295`;
+exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543 gas [ @skip-on-coverage ] 1`] = `2295`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543 result 1`] = `-276325`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950 gas 1`] = `2244`;
+exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950 gas [ @skip-on-coverage ] 1`] = `2244`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950 result 1`] = `-138163`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 9903520314283042199192993792 gas 1`] = `1390`;
+exports[`TickMath #getTickAtSqrtRatio ratio 9903520314283042199192993792 gas [ @skip-on-coverage ] 1`] = `1390`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 9903520314283042199192993792 result 1`] = `-41591`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 28011385487393069959365969113 gas 1`] = `2217`;
+exports[`TickMath #getTickAtSqrtRatio ratio 28011385487393069959365969113 gas [ @skip-on-coverage ] 1`] = `2217`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 28011385487393069959365969113 result 1`] = `-20796`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 56022770974786139918731938227 gas 1`] = `2203`;
+exports[`TickMath #getTickAtSqrtRatio ratio 56022770974786139918731938227 gas [ @skip-on-coverage ] 1`] = `2203`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 56022770974786139918731938227 result 1`] = `-6932`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950336 gas 1`] = `2129`;
+exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950336 gas [ @skip-on-coverage ] 1`] = `2129`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950336 result 1`] = `0`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 112045541949572279837463876454 gas 1`] = `2229`;
+exports[`TickMath #getTickAtSqrtRatio ratio 112045541949572279837463876454 gas [ @skip-on-coverage ] 1`] = `2229`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 112045541949572279837463876454 result 1`] = `6931`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 224091083899144559674927752909 gas 1`] = `2243`;
+exports[`TickMath #getTickAtSqrtRatio ratio 224091083899144559674927752909 gas [ @skip-on-coverage ] 1`] = `2243`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 224091083899144559674927752909 result 1`] = `20795`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 633825300114114700748351602688 gas 1`] = `2256`;
+exports[`TickMath #getTickAtSqrtRatio ratio 633825300114114700748351602688 gas [ @skip-on-coverage ] 1`] = `2256`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 633825300114114700748351602688 result 1`] = `41590`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950336000 gas 1`] = `2266`;
+exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950336000 gas [ @skip-on-coverage ] 1`] = `2266`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950336000 result 1`] = `138162`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950336000000 gas 1`] = `2317`;
+exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950336000000 gas [ @skip-on-coverage ] 1`] = `2317`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 79228162514264337593543950336000000 result 1`] = `276324`;
 
-exports[`TickMath #getTickAtSqrtRatio ratio 1461446703485210103287273052203988822378723970341 gas 1`] = `2330`;
+exports[`TickMath #getTickAtSqrtRatio ratio 1461446703485210103287273052203988822378723970341 gas [ @skip-on-coverage ] 1`] = `2330`;
 
 exports[`TickMath #getTickAtSqrtRatio ratio 1461446703485210103287273052203988822378723970341 result 1`] = `887271`;

--- a/src/core/test/shared/snapshotGasCost.ts
+++ b/src/core/test/shared/snapshotGasCost.ts
@@ -1,27 +1,27 @@
 import { TransactionReceipt, TransactionResponse } from '@ethersproject/abstract-provider';
 import { expect } from './expect';
-import { Contract, BigNumber, ContractTransaction } from 'ethers';
+import { Contract, ContractTransaction, ContractTransactionResponse } from 'ethers';
 
 export default async function snapshotGasCost(
   x:
     | TransactionResponse
     | Promise<TransactionResponse>
-    | ContractTransaction
-    | Promise<ContractTransaction>
+    | ContractTransactionResponse
+    | Promise<ContractTransactionResponse>
     | TransactionReceipt
-    | Promise<BigNumber>
-    | BigNumber
+    | Promise<BigInt>
+    | BigInt
     | Contract
     | Promise<Contract>
 ): Promise<void> {
   const resolved = await x;
-  if ('deployTransaction' in resolved) {
+  if (typeof resolved == 'bigint' || resolved instanceof Number || typeof resolved == 'number') {
+    expect(Number(resolved)).toMatchSnapshot();
+  } else if ('deployTransaction' in resolved) {
     const receipt = await resolved.deployTransaction.wait();
     expect(receipt.gasUsed.toNumber()).toMatchSnapshot();
   } else if ('wait' in resolved) {
     const waited = await resolved.wait();
-    expect(waited.gasUsed.toNumber()).toMatchSnapshot();
-  } else if (BigNumber.isBigNumber(resolved)) {
-    expect(resolved.toNumber()).toMatchSnapshot();
+    expect(Number(waited.gasUsed)).toMatchSnapshot();
   }
 }


### PR DESCRIPTION
In the tests of the Core module, the version of ethers was changed to the 6. Passing tests has accelerated a little, tests are a little more convenient to write.

https://docs.ethers.org/v6/migrating/