### PR TITLE
Small changes after mixbytes audit

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           check_hidden: true
           check_filenames: true
-          skip: *.yml,package-lock.json,node_modules
+          skip: package-lock.json,node_modules

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,24 @@
+name: checks
+
+on:
+  push:
+    branches:
+      - master
+      - staged
+  pull_request: {}
+  workflow_dispatch: {}
+
+env:
+  NODE_OPTIONS: --max_old_space_size=5120
+
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run CodeSpell
+        uses: codespell-project/actions-codespell@v2.0
+        with:
+          check_hidden: true
+          check_filenames: true
+          skip: package-lock.json,node_modules

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           check_hidden: true
           check_filenames: true
-          skip: package-lock.json,node_modules
+          skip: package-lock.json,node_modules,Base64.spec.ts.snap

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,7 +6,6 @@ on:
       - master
       - staged
   pull_request: {}
-  workflow_dispatch: {}
 
 env:
   NODE_OPTIONS: --max_old_space_size=5120
@@ -21,4 +20,4 @@ jobs:
         with:
           check_hidden: true
           check_filenames: true
-          skip: package-lock.json,node_modules
+          skip: *.yml,package-lock.json,node_modules

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,17 +1,16 @@
-name: checks
+name: Checks
 
 on:
   push:
     branches:
       - master
       - staged
-  pull_request: {}
-
-env:
-  NODE_OPTIONS: --max_old_space_size=5120
+  pull_request:
+    branches:
+      - dev
 
 jobs:
-  codespell:
+  Codespell:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.solhint.json
+++ b/.solhint.json
@@ -1,6 +1,15 @@
 {
-  "extends": "solhint:default",
+  "extends": "solhint:recommended",
+  "plugins": [],
   "rules": {
-    "max-line-length": "off"
+    "max-line-length": "off",
+    "no-global-import": "off",
+    "quotes": ["error", "single"],
+    "custom-errors": "off",
+    "func-visibility": ["warn", {"ignoreConstructors":true}],
+    "no-inline-assembly": "off",
+    "compiler-version": "off",
+    "comprehensive-interface": "warn",
+    "modifier-name-mixedcase": "error"
   }
 }

--- a/docs/Contracts/Core/AlgebraCommunityVault.md
+++ b/docs/Contracts/Core/AlgebraCommunityVault.md
@@ -131,7 +131,8 @@ function acceptAlgebraFeeChangeProposal(uint16 newAlgebraFee) external
 
 Accepts the proposed new Algebra fee
 
-*Developer note: Can only be called by the factory owner*
+*Developer note: Can only be called by the factory owner.
+The new value will also be used for previously accumulated tokens that have not yet been withdrawn*
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
@@ -178,6 +179,8 @@ function proposeAlgebraFeeChange(uint16 newAlgebraFee) external
 ```
 
 Proposes new Algebra fee value for protocol
+
+*Developer note: the new value will also be used for previously accumulated tokens that have not yet been withdrawn*
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |

--- a/docs/Contracts/Core/AlgebraCommunityVault.md
+++ b/docs/Contracts/Core/AlgebraCommunityVault.md
@@ -11,10 +11,10 @@ Community fee from pools is sent here, if it is enabled
 Version: Algebra Integral*
 
 ## Modifiers
-### onlyFactoryOwner
+### onlyAdministrator
 
 ```solidity
-modifier onlyFactoryOwner()
+modifier onlyAdministrator()
 ```
 
 
@@ -38,6 +38,12 @@ modifier onlyAlgebraFeeManager()
 
 ## Variables
 ### bytes32 COMMUNITY_FEE_WITHDRAWER_ROLE constant
+
+
+
+*Developer note: The role can be granted in AlgebraFactory*
+
+### bytes32 COMMUNITY_FEE_VAULT_ADMINISTRATOR constant
 
 
 

--- a/docs/Contracts/Core/AlgebraFactory.md
+++ b/docs/Contracts/Core/AlgebraFactory.md
@@ -57,6 +57,12 @@ Returns the pool address for a given pair of tokens, or address 0 if it does not
 
 *Developer note: tokenA and tokenB may be passed in either token0/token1 or token1/token0 order*
 
+### bytes32 POOL_INIT_CODE_HASH constant
+
+returns keccak256 of AlgebraPool init bytecode.
+
+*Developer note: keccak256 of AlgebraPool init bytecode. Used to compute pool address deterministically*
+
 
 ## Functions
 ### constructor

--- a/docs/Contracts/Core/interfaces/IAlgebraCommunityVault.md
+++ b/docs/Contracts/Core/interfaces/IAlgebraCommunityVault.md
@@ -171,7 +171,8 @@ function acceptAlgebraFeeChangeProposal(uint16 newAlgebraFee) external
 
 Accepts the proposed new Algebra fee
 
-*Developer note: Can only be called by the factory owner*
+*Developer note: Can only be called by the factory owner.
+The new value will also be used for previously accumulated tokens that have not yet been withdrawn*
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
@@ -218,6 +219,8 @@ function proposeAlgebraFeeChange(uint16 newAlgebraFee) external
 ```
 
 Proposes new Algebra fee value for protocol
+
+*Developer note: the new value will also be used for previously accumulated tokens that have not yet been withdrawn*
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |

--- a/docs/Contracts/Core/interfaces/IAlgebraFactory.md
+++ b/docs/Contracts/Core/interfaces/IAlgebraFactory.md
@@ -304,6 +304,22 @@ Returns the pool address for a given pair of tokens, or address 0 if it does not
 | ---- | ---- | ----------- |
 | pool | address | The pool address |
 
+### POOL_INIT_CODE_HASH
+
+```solidity
+function POOL_INIT_CODE_HASH() external view returns (bytes32)
+```
+
+returns keccak256 of AlgebraPool init bytecode.
+
+*Developer note: the hash value changes with any change in the pool bytecode*
+
+**Returns:**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [0] | bytes32 | Keccak256 hash of AlgebraPool contract init bytecode |
+
 ### renounceOwnershipStartTimestamp
 
 ```solidity

--- a/docs/Contracts/Core/interfaces/IAlgebraPoolErrors.md
+++ b/docs/Contracts/Core/interfaces/IAlgebraPoolErrors.md
@@ -145,6 +145,14 @@ error dynamicFeeDisabled()
 
 
 
+## pluginIsNotConnected
+
+```solidity
+error pluginIsNotConnected()
+```
+
+
+
 ## invalidHookResponse
 
 ```solidity

--- a/docs/Contracts/Core/interfaces/IAlgebraPoolErrors.md
+++ b/docs/Contracts/Core/interfaces/IAlgebraPoolErrors.md
@@ -25,6 +25,14 @@ error alreadyInitialized()
 
 Emitted if an attempt is made to initialize the pool twice
 
+## notInitialized
+
+```solidity
+error notInitialized()
+```
+
+Emitted if an attempt is made to mint or swap in uninitialized pool
+
 ## zeroAmountRequired
 
 ```solidity
@@ -39,7 +47,7 @@ Emitted if 0 is passed as amountRequired to swap function
 error invalidAmountRequired()
 ```
 
-Emitted if invalid amount is passed as amountRequired to swapSupportingFeeOnInputTokens function
+Emitted if invalid amount is passed as amountRequired to swap function
 
 ## insufficientInputAmount
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "prettier-check": "^2.0.0",
         "prettier-plugin-solidity": "^1.1.3",
         "pretty-quick": "^3.1.1",
-        "solhint": "^3.4.1",
+        "solhint": "^3.6.2",
         "solhint-plugin-prettier": "^0.0.5",
         "solidity-docgen": "^0.6.0-beta.35",
         "ts-generator": "^0.1.1",
@@ -18098,9 +18098,9 @@
       }
     },
     "node_modules/solhint": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/solhint/-/solhint-3.5.1.tgz",
-      "integrity": "sha512-29+vUIwUmsasKuIzCYOqiKlu4We7+BVYNuoKmDMWsmjfPDoJQpM65eBzYuqEr18lwvXpQAbjTGdzvm4iZIO9Uw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/solhint/-/solhint-3.6.2.tgz",
+      "integrity": "sha512-85EeLbmkcPwD+3JR7aEMKsVC9YrRSxd4qkXuMzrlf7+z2Eqdfm1wHWq1ffTuo5aDhoZxp2I9yF3QkxZOxOL7aQ==",
       "dev": true,
       "dependencies": {
         "@solidity-parser/parser": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prettier-check": "^2.0.0",
     "prettier-plugin-solidity": "^1.1.3",
     "pretty-quick": "^3.1.1",
-    "solhint": "^3.4.1",
+    "solhint": "^3.6.2",
     "solhint-plugin-prettier": "^0.0.5",
     "solidity-docgen": "^0.6.0-beta.35",
     "ts-generator": "^0.1.1",

--- a/src/core/.solhintignore
+++ b/src/core/.solhintignore
@@ -1,0 +1,1 @@
+./contracts/test/

--- a/src/core/contracts/AlgebraCommunityVault.sol
+++ b/src/core/contracts/AlgebraCommunityVault.sol
@@ -96,6 +96,7 @@ contract AlgebraCommunityVault is IAlgebraCommunityVault {
     require(hasNewAlgebraFeeProposal, 'not proposed');
     require(newAlgebraFee == proposedNewAlgebraFee, 'invalid new fee');
 
+    // note that the new value will be used for previously accumulated tokens that have not yet been withdrawn
     algebraFee = newAlgebraFee;
     (proposedNewAlgebraFee, hasNewAlgebraFeeProposal) = (0, false);
     emit AlgebraFee(newAlgebraFee);

--- a/src/core/contracts/AlgebraFactory.sol
+++ b/src/core/contracts/AlgebraFactory.sol
@@ -72,7 +72,7 @@ contract AlgebraFactory is IAlgebraFactory, Ownable2Step, AccessControlEnumerabl
   }
 
   /// @inheritdoc IAlgebraFactory
-  function defaultConfigurationForPool() external view returns (uint16 communityFee, int24 tickSpacing, uint16 fee) {
+  function defaultConfigurationForPool() external view override returns (uint16 communityFee, int24 tickSpacing, uint16 fee) {
     return (defaultCommunityFee, defaultTickspacing, defaultFee);
   }
 

--- a/src/core/contracts/AlgebraFactory.sol
+++ b/src/core/contracts/AlgebraFactory.sol
@@ -46,8 +46,9 @@ contract AlgebraFactory is IAlgebraFactory, Ownable2Step, AccessControlEnumerabl
   /// @inheritdoc IAlgebraFactory
   mapping(address => mapping(address => address)) public override poolByPair;
 
+  /// @inheritdoc IAlgebraFactory
   /// @dev keccak256 of AlgebraPool init bytecode. Used to compute pool address deterministically
-  bytes32 private constant POOL_INIT_CODE_HASH = 0x61b0e9f440885c12064d37d2b40505fa24d8ca39f690c9ad18a79806cdceca38;
+  bytes32 public constant POOL_INIT_CODE_HASH = 0x61b0e9f440885c12064d37d2b40505fa24d8ca39f690c9ad18a79806cdceca38;
 
   constructor(address _poolDeployer) {
     require(_poolDeployer != address(0));

--- a/src/core/contracts/AlgebraFactory.sol
+++ b/src/core/contracts/AlgebraFactory.sol
@@ -48,7 +48,7 @@ contract AlgebraFactory is IAlgebraFactory, Ownable2Step, AccessControlEnumerabl
 
   /// @inheritdoc IAlgebraFactory
   /// @dev keccak256 of AlgebraPool init bytecode. Used to compute pool address deterministically
-  bytes32 public constant POOL_INIT_CODE_HASH = 0x61b0e9f440885c12064d37d2b40505fa24d8ca39f690c9ad18a79806cdceca38;
+  bytes32 public constant POOL_INIT_CODE_HASH = 0x634db8d334cf38f8d669064fefe5c4f5cf194cab753e4ed23256fb4dd545ed7a;
 
   constructor(address _poolDeployer) {
     require(_poolDeployer != address(0));

--- a/src/core/contracts/AlgebraPool.sol
+++ b/src/core/contracts/AlgebraPool.sol
@@ -143,6 +143,8 @@ contract AlgebraPool is AlgebraPoolBase, TickStructure, ReentrancyGuard, Positio
     (amount0, amount1) = _updatePositionTicksAndFees(position, bottomTick, topTick, liquidityDelta);
 
     if (amount0 | amount1 != 0) {
+      // since we do not support tokens whose total supply can exceed uint128, these casts are safe
+      // and, theoretically, unchecked cast prevents a complete blocking of burn
       (position.fees0, position.fees1) = (position.fees0 + uint128(amount0), position.fees1 + uint128(amount1));
     }
 

--- a/src/core/contracts/base/SwapCalculation.sol
+++ b/src/core/contracts/base/SwapCalculation.sol
@@ -47,9 +47,11 @@ abstract contract SwapCalculation is AlgebraPoolBase {
     (cache.amountRequiredInitial, cache.exactInput) = (amountRequired, amountRequired > 0);
 
     // load from one storage slot
-    (currentPrice, currentTick, cache.fee, cache.communityFee) = (globalState.price, globalState.tick, globalState.fee, globalState.communityFee);
-    // load from one storage slot too
     (currentLiquidity, cache.prevInitializedTick, cache.nextInitializedTick) = (liquidity, prevTickGlobal, nextTickGlobal);
+
+    // load from one storage slot too
+    (currentPrice, currentTick, cache.fee, cache.communityFee) = (globalState.price, globalState.tick, globalState.fee, globalState.communityFee);
+    if (currentPrice == 0) revert notInitialized();
 
     if (zeroToOne) {
       if (limitSqrtPrice >= currentPrice || limitSqrtPrice <= TickMath.MIN_SQRT_RATIO) revert invalidLimitSqrtPrice();

--- a/src/core/contracts/interfaces/IAlgebraCommunityVault.sol
+++ b/src/core/contracts/interfaces/IAlgebraCommunityVault.sol
@@ -63,7 +63,8 @@ interface IAlgebraCommunityVault {
   // ### algebra factory owner permissioned actions ###
 
   /// @notice Accepts the proposed new Algebra fee
-  /// @dev Can only be called by the factory owner
+  /// @dev Can only be called by the factory owner.
+  /// The new value will also be used for previously accumulated tokens that have not yet been withdrawn
   /// @param newAlgebraFee New Algebra fee value
   function acceptAlgebraFeeChangeProposal(uint16 newAlgebraFee) external;
 
@@ -82,6 +83,7 @@ interface IAlgebraCommunityVault {
   function acceptAlgebraFeeManagerRole() external;
 
   /// @notice Proposes new Algebra fee value for protocol
+  /// @dev the new value will also be used for previously accumulated tokens that have not yet been withdrawn
   /// @param newAlgebraFee new Algebra fee value
   function proposeAlgebraFeeChange(uint16 newAlgebraFee) external;
 

--- a/src/core/contracts/interfaces/IAlgebraFactory.sol
+++ b/src/core/contracts/interfaces/IAlgebraFactory.sol
@@ -102,6 +102,11 @@ interface IAlgebraFactory {
   /// @return pool The pool address
   function poolByPair(address tokenA, address tokenB) external view returns (address pool);
 
+  /// @notice returns keccak256 of AlgebraPool init bytecode.
+  /// @dev the hash value changes with any change in the pool bytecode
+  /// @return Keccak256 hash of AlgebraPool contract init bytecode
+  function POOL_INIT_CODE_HASH() external view returns (bytes32);
+
   /// @return timestamp The timestamp of the beginning of the renounceOwnership process
   function renounceOwnershipStartTimestamp() external view returns (uint256 timestamp);
 

--- a/src/core/contracts/interfaces/pool/IAlgebraPoolErrors.sol
+++ b/src/core/contracts/interfaces/pool/IAlgebraPoolErrors.sol
@@ -16,6 +16,9 @@ interface IAlgebraPoolErrors {
   /// @notice Emitted if an attempt is made to initialize the pool twice
   error alreadyInitialized();
 
+  /// @notice Emitted if an attempt is made to mint or swap in uninitialized pool
+  error notInitialized();
+
   /// @notice Emitted if 0 is passed as amountRequired to swap function
   error zeroAmountRequired();
 

--- a/src/core/contracts/interfaces/pool/IAlgebraPoolErrors.sol
+++ b/src/core/contracts/interfaces/pool/IAlgebraPoolErrors.sol
@@ -22,7 +22,7 @@ interface IAlgebraPoolErrors {
   /// @notice Emitted if 0 is passed as amountRequired to swap function
   error zeroAmountRequired();
 
-  /// @notice Emitted if invalid amount is passed as amountRequired to swapSupportingFeeOnInputTokens function
+  /// @notice Emitted if invalid amount is passed as amountRequired to swap function
   error invalidAmountRequired();
 
   /// @notice Emitted if the pool received fewer tokens than it should have

--- a/src/core/contracts/libraries/Constants.sol
+++ b/src/core/contracts/libraries/Constants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.20;
+pragma solidity >=0.5.0 <0.9.0;
 
 /// @title Contains common constants for Algebra contracts
 /// @dev Constants moved to the library, not the base contract, to further emphasize their constant nature
@@ -25,6 +25,6 @@ library Constants {
 
   uint16 internal constant MAX_COMMUNITY_FEE = 1e3; // 100%
   uint256 internal constant COMMUNITY_FEE_DENOMINATOR = 1e3;
-  // role that can change communityFee and tickspacing in pools
+  // role that can change settings in pools
   bytes32 internal constant POOLS_ADMINISTRATOR_ROLE = keccak256('POOLS_ADMINISTRATOR');
 }

--- a/src/core/contracts/libraries/Plugins.sol
+++ b/src/core/contracts/libraries/Plugins.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.20;
+pragma solidity >=0.8.4 <0.9.0;
 
 import '../interfaces/pool/IAlgebraPoolErrors.sol';
 

--- a/src/core/contracts/libraries/PriceMovementMath.sol
+++ b/src/core/contracts/libraries/PriceMovementMath.sol
@@ -79,19 +79,19 @@ library PriceMovementMath {
     }
   }
 
-  function getTokenADelta01(uint160 to, uint160 from, uint128 liquidity) internal pure returns (uint256) {
+  function getInputTokenDelta01(uint160 to, uint160 from, uint128 liquidity) internal pure returns (uint256) {
     return TokenDeltaMath.getToken0Delta(to, from, liquidity, true);
   }
 
-  function getTokenADelta10(uint160 to, uint160 from, uint128 liquidity) internal pure returns (uint256) {
+  function getInputTokenDelta10(uint160 to, uint160 from, uint128 liquidity) internal pure returns (uint256) {
     return TokenDeltaMath.getToken1Delta(from, to, liquidity, true);
   }
 
-  function getTokenBDelta01(uint160 to, uint160 from, uint128 liquidity) internal pure returns (uint256) {
+  function getOutputTokenDelta01(uint160 to, uint160 from, uint128 liquidity) internal pure returns (uint256) {
     return TokenDeltaMath.getToken1Delta(to, from, liquidity, false);
   }
 
-  function getTokenBDelta10(uint160 to, uint160 from, uint128 liquidity) internal pure returns (uint256) {
+  function getOutputTokenDelta10(uint160 to, uint160 from, uint128 liquidity) internal pure returns (uint256) {
     return TokenDeltaMath.getToken0Delta(from, to, liquidity, false);
   }
 
@@ -116,12 +116,12 @@ library PriceMovementMath {
     uint16 fee
   ) internal pure returns (uint160 resultPrice, uint256 input, uint256 output, uint256 feeAmount) {
     unchecked {
-      function(uint160, uint160, uint128) pure returns (uint256) getAmountA = zeroToOne ? getTokenADelta01 : getTokenADelta10;
+      function(uint160, uint160, uint128) pure returns (uint256) getInputTokenAmount = zeroToOne ? getInputTokenDelta01 : getInputTokenDelta10;
 
       if (amountAvailable >= 0) {
         // exactIn or not
         uint256 amountAvailableAfterFee = FullMath.mulDiv(uint256(amountAvailable), Constants.FEE_DENOMINATOR - fee, Constants.FEE_DENOMINATOR);
-        input = getAmountA(targetPrice, currentPrice, liquidity);
+        input = getInputTokenAmount(targetPrice, currentPrice, liquidity);
         if (amountAvailableAfterFee >= input) {
           resultPrice = targetPrice;
           feeAmount = FullMath.mulDivRoundingUp(input, fee, Constants.FEE_DENOMINATOR - fee);
@@ -129,16 +129,16 @@ library PriceMovementMath {
           resultPrice = getNewPriceAfterInput(currentPrice, liquidity, amountAvailableAfterFee, zeroToOne);
           assert(targetPrice != resultPrice); // should always be true
 
-          input = getAmountA(resultPrice, currentPrice, liquidity);
+          input = getInputTokenAmount(resultPrice, currentPrice, liquidity);
           // we didn't reach the target, so take the remainder of the maximum input as fee
           feeAmount = uint256(amountAvailable) - input;
         }
 
-        output = (zeroToOne ? getTokenBDelta01 : getTokenBDelta10)(resultPrice, currentPrice, liquidity);
+        output = (zeroToOne ? getOutputTokenDelta01 : getOutputTokenDelta10)(resultPrice, currentPrice, liquidity);
       } else {
-        function(uint160, uint160, uint128) pure returns (uint256) getAmountB = zeroToOne ? getTokenBDelta01 : getTokenBDelta10;
+        function(uint160, uint160, uint128) pure returns (uint256) getOutputTokenAmount = zeroToOne ? getOutputTokenDelta01 : getOutputTokenDelta10;
 
-        output = getAmountB(targetPrice, currentPrice, liquidity);
+        output = getOutputTokenAmount(targetPrice, currentPrice, liquidity);
         amountAvailable = -amountAvailable;
         if (amountAvailable < 0) revert IAlgebraPoolErrors.invalidAmountRequired(); // in case of type(int256).min
 
@@ -147,13 +147,13 @@ library PriceMovementMath {
           resultPrice = getNewPriceAfterOutput(currentPrice, liquidity, uint256(amountAvailable), zeroToOne);
 
           // should be always true if the price is in the allowed range
-          if (targetPrice != resultPrice) output = getAmountB(resultPrice, currentPrice, liquidity);
+          if (targetPrice != resultPrice) output = getOutputTokenAmount(resultPrice, currentPrice, liquidity);
 
           // cap the output amount to not exceed the remaining output amount
           if (output > uint256(amountAvailable)) output = uint256(amountAvailable);
         }
 
-        input = getAmountA(resultPrice, currentPrice, liquidity);
+        input = getInputTokenAmount(resultPrice, currentPrice, liquidity);
         feeAmount = FullMath.mulDivRoundingUp(input, fee, Constants.FEE_DENOMINATOR - fee);
       }
     }

--- a/src/core/contracts/libraries/PriceMovementMath.sol
+++ b/src/core/contracts/libraries/PriceMovementMath.sol
@@ -131,7 +131,7 @@ library PriceMovementMath {
 
           input = getInputTokenAmount(resultPrice, currentPrice, liquidity);
           // we didn't reach the target, so take the remainder of the maximum input as fee
-          feeAmount = uint256(amountAvailable) - input;
+          feeAmount = uint256(amountAvailable) - input; // input <= amountAvailable due to used formulas. This invariant is checked by fuzzy tests
         }
 
         output = (zeroToOne ? getOutputTokenDelta01 : getOutputTokenDelta10)(resultPrice, currentPrice, liquidity);

--- a/src/core/contracts/test/MockPoolPlugin.sol
+++ b/src/core/contracts/test/MockPoolPlugin.sol
@@ -47,8 +47,8 @@ contract MockPoolPlugin is IAlgebraPlugin, IAlgebraDynamicFeePlugin {
     int256 amount1,
     bytes data
   );
-  event BeforeFlash(address sender, address recepient, uint256 amount0, uint256 amount1, bytes data);
-  event AfterFlash(address sender, address recepient, uint256 amount0, uint256 amount1, uint256 paid0, uint256 paid1, bytes data);
+  event BeforeFlash(address sender, address recipient, uint256 amount0, uint256 amount1, bytes data);
+  event AfterFlash(address sender, address recipient, uint256 amount0, uint256 amount1, uint256 paid0, uint256 paid1, bytes data);
 
   function defaultPluginConfig() external view override returns (uint8) {}
 
@@ -137,7 +137,7 @@ contract MockPoolPlugin is IAlgebraPlugin, IAlgebraDynamicFeePlugin {
   /// @return bytes4 The function selector for the hook
   function afterSwap(
     address sender,
-    address recepient,
+    address recipient,
     bool zeroToOne,
     int256 amountRequired,
     uint160 limitSqrtPrice,
@@ -145,7 +145,7 @@ contract MockPoolPlugin is IAlgebraPlugin, IAlgebraDynamicFeePlugin {
     int256 amount1,
     bytes calldata data
   ) external override returns (bytes4) {
-    emit AfterSwap(sender, recepient, zeroToOne, amountRequired, limitSqrtPrice, amount0, amount1, data);
+    emit AfterSwap(sender, recipient, zeroToOne, amountRequired, limitSqrtPrice, amount0, amount1, data);
     if (!Plugins.hasFlag(selectorsDisableConfig, Plugins.AFTER_SWAP_FLAG)) return IAlgebraPlugin.afterSwap.selector;
     return IAlgebraPlugin.defaultPluginConfig.selector;
   }

--- a/src/core/contracts/test/echidna/PoolMockEchidna/PoolMockEchidna.sol
+++ b/src/core/contracts/test/echidna/PoolMockEchidna/PoolMockEchidna.sol
@@ -62,7 +62,7 @@ contract PoolMockEchidna is AlgebraPool {
     IAlgebraPool(this).flash(recipient, amount0, amount1, data);
   }
 
-  function swapSupportingFeeOnInputTokensWrapped(bool zeroToOne, int256 amountRequired, uint160 limitSqrtPrice, uint256 pay0, uint256 pay1) public {
+  function swapWithPaymentInAdvanceWrapped(bool zeroToOne, int256 amountRequired, uint160 limitSqrtPrice, uint256 pay0, uint256 pay1) public {
     bytes memory data = abi.encode(MintData(pay0, pay1));
     IAlgebraPool(this).swapWithPaymentInAdvance(address(this), address(this), zeroToOne, amountRequired, limitSqrtPrice, data);
   }

--- a/src/core/contracts/test/echidna/PoolMockEchidna/echidna-assert.config.yml
+++ b/src/core/contracts/test/echidna/PoolMockEchidna/echidna-assert.config.yml
@@ -45,7 +45,7 @@ coverage: false
 # quiet: false
 # #initialize the blockchain with some data
 # initialize: null
-# #whether ot not to use the multi-abi mode of testing
+# #whether or not to use the multi-abi mode of testing
 # multi-abi: false
 # #benchmarkMode enables benchmark mode
 # benchmarkMode: false

--- a/src/core/contracts/test/echidna/PoolMockEchidna/echidna-property.config.yml
+++ b/src/core/contracts/test/echidna/PoolMockEchidna/echidna-property.config.yml
@@ -45,7 +45,7 @@ coverage: false
 # quiet: false
 # #initialize the blockchain with some data
 # initialize: null
-# #whether ot not to use the multi-abi mode of testing
+# #whether or not to use the multi-abi mode of testing
 # multi-abi: false
 # #benchmarkMode enables benchmark mode
 # benchmarkMode: false

--- a/src/core/contracts/test/echidna/PriceMovementMathEchidnaTest.sol
+++ b/src/core/contracts/test/echidna/PriceMovementMathEchidnaTest.sol
@@ -5,7 +5,7 @@ import '../../libraries/PriceMovementMath.sol';
 import '../../libraries/TickMath.sol';
 
 contract PriceMovementMathEchidnaTest {
-  function checkmovePriceTowardsTargetInvariants(
+  function checkMovePriceTowardsTargetInvariants(
     uint160 sqrtPriceRaw,
     uint160 sqrtPriceTargetRaw,
     uint128 liquidity,
@@ -60,5 +60,17 @@ contract PriceMovementMathEchidnaTest {
         assert(sqrtQ <= sqrtPriceTargetRaw);
       }
     }
+  }
+
+  function checkGetNewPriceAfterInputInvariantZtO(uint160 price, uint128 liquidity, uint256 amount) external pure {
+    uint160 newPrice = PriceMovementMath.getNewPriceAfterInput(price, liquidity, amount, true);
+    uint256 requiredTokenAmount = PriceMovementMath.getInputTokenDelta01(newPrice, price, liquidity);
+    assert(requiredTokenAmount <= amount);
+  }
+
+  function checkGetNewPriceAfterInputInvariantOtZ(uint160 price, uint128 liquidity, uint256 amount) external pure {
+    uint160 newPrice = PriceMovementMath.getNewPriceAfterInput(price, liquidity, amount, false);
+    uint256 requiredTokenAmount = PriceMovementMath.getInputTokenDelta10(newPrice, price, liquidity);
+    assert(requiredTokenAmount <= amount);
   }
 }

--- a/src/core/contracts/test/echidna/echidna.config.yml
+++ b/src/core/contracts/test/echidna/echidna.config.yml
@@ -45,7 +45,7 @@ coverage: false
 # quiet: false
 # #initialize the blockchain with some data
 # initialize: null
-# #whether ot not to use the multi-abi mode of testing
+# #whether or not to use the multi-abi mode of testing
 # multi-abi: false
 # #benchmarkMode enables benchmark mode
 # benchmarkMode: false

--- a/src/core/package.json
+++ b/src/core/package.json
@@ -25,6 +25,7 @@
   ],
   "scripts": {
     "precommit": "pretty-quick --staged --pattern **/*.sol && hardhat compile && node ../../scripts/updatePoolHash.js",
+    "solhint": "solhint ./contracts/**/*.sol",
     "compile": "hardhat compile",
     "test": "hardhat test --parallel",
     "coverage": "hardhat coverage --solcoverjs ./.solcover.js",

--- a/src/core/test/AlgebraFactory.spec.ts
+++ b/src/core/test/AlgebraFactory.spec.ts
@@ -1,4 +1,4 @@
-import { Wallet, getCreateAddress, ZeroAddress } from 'ethers';
+import { Wallet, getCreateAddress, ZeroAddress, keccak256 } from 'ethers';
 import { ethers } from 'hardhat';
 import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
 import { AlgebraFactory, AlgebraPoolDeployer, MockDefaultPluginFactory } from '../typechain';
@@ -58,6 +58,14 @@ describe('AlgebraFactory', () => {
 
   it('owner is deployer', async () => {
     expect(await factory.owner()).to.eq(wallet.address);
+  });
+
+  it('has POOL_INIT_CODE_HASH', async () => {
+    expect(await factory.POOL_INIT_CODE_HASH()).to.be.not.eq('0x0000000000000000000000000000000000000000000000000000000000000000');
+  });
+
+  it('has correct POOL_INIT_CODE_HASH [ @skip-on-coverage ]', async () => {
+    expect(await factory.POOL_INIT_CODE_HASH()).to.be.eq(keccak256(poolBytecode));
   });
 
   it('cannot deploy factory with incorrect poolDeployer', async () => {

--- a/src/core/test/AlgebraFactory.spec.ts
+++ b/src/core/test/AlgebraFactory.spec.ts
@@ -120,7 +120,7 @@ describe('AlgebraFactory', () => {
       expect(addressCalculatedByFactory).to.be.eq(poolAddress);
     });
 
-    it('succeeds if defaultPluginFactory setted [ @skip-on-coverage ]', async () => {
+    it('succeeds if defaultPluginFactory set [ @skip-on-coverage ]', async () => {
       await factory.setDefaultPluginFactory(defaultPluginFactory);
       await createAndCheckPool([TEST_ADDRESSES[0], TEST_ADDRESSES[1]]);
 

--- a/src/core/test/AlgebraPool.spec.ts
+++ b/src/core/test/AlgebraPool.spec.ts
@@ -172,12 +172,12 @@ describe('AlgebraPool', () => {
 
   describe('#mint', () => {
     it('fails if not initialized', async () => {
-      expect(mint(wallet.address, -tickSpacing, tickSpacing, 1)).to.be.revertedWithoutReason;
-      expect(mint(wallet.address, getMinTick(1), getMaxTick(1), 100)).to.be.revertedWithoutReason;
-      expect(mint(wallet.address, 0, getMaxTick(1), 100)).to.be.revertedWithoutReason;
-      expect(mint(wallet.address, getMinTick(1), 0, 100)).to.be.revertedWithoutReason;
-      expect(mint(wallet.address, getMaxTick(1) - 1, getMaxTick(1), 100)).to.be.revertedWithoutReason;
-      expect(mint(wallet.address, getMinTick(1), getMinTick(1) + 1, 100)).to.be.revertedWithoutReason;
+      await expect(mint(wallet.address, -tickSpacing, tickSpacing, 1)).to.be.revertedWithCustomError(pool, 'notInitialized');
+      await expect(mint(wallet.address, getMinTick(1), getMaxTick(1), 100)).to.be.revertedWithCustomError(pool, 'notInitialized');
+      await expect(mint(wallet.address, 0, getMaxTick(1), 100)).to.be.revertedWithCustomError(pool, 'notInitialized');
+      await expect(mint(wallet.address, getMinTick(1), 0, 100)).to.be.revertedWithCustomError(pool, 'notInitialized');
+      await expect(mint(wallet.address, getMaxTick(1) - 1, getMaxTick(1), 100)).to.be.revertedWithCustomError(pool, 'notInitialized');
+      await expect(mint(wallet.address, getMinTick(1), getMinTick(1) + 1, 100)).to.be.revertedWithCustomError(pool, 'notInitialized');
     });
     describe('after initialization', () => {
       beforeEach('initialize the pool at price of 10:1', async () => {
@@ -1167,7 +1167,7 @@ describe('AlgebraPool', () => {
   describe('#swaps', () => {
     describe('#swap', async () => {
       it('fails if not initialized', async () => {
-        expect(swapToLowerPrice(encodePriceSqrt(1, 5), other.address)).to.be.revertedWithoutReason;
+        await expect(swapToLowerPrice(encodePriceSqrt(1, 5), other.address)).to.be.revertedWithCustomError(pool, 'notInitialized');
       });
       describe('after initialization', () => {
         beforeEach('initialize the pool at price of 10:1', async () => {
@@ -1229,7 +1229,7 @@ describe('AlgebraPool', () => {
 
     describe('#swapWithPaymentInAdvance', async () => {
       it('fails if not initialized', async () => {
-        expect(swapExact0For1SupportingFee(100, other.address)).to.be.revertedWithoutReason;
+        expect(swapExact0For1SupportingFee(100, other.address)).to.be.revertedWithCustomError(pool, 'notInitialized');
       });
       describe('after initialization', () => {
         beforeEach('initialize the pool at price of 10:1', async () => {

--- a/src/core/test/AlgebraPool.spec.ts
+++ b/src/core/test/AlgebraPool.spec.ts
@@ -196,7 +196,7 @@ describe('AlgebraPool', () => {
             await token1.approve(payer, 2n ** 256n - 1n);
           });
 
-          it('fails if token0 payed 0', async () => {
+          it('fails if token0 paid 0', async () => {
             await expect(
               payer.mint(pool, wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 100, 0, 100)
             ).to.be.revertedWithCustomError(pool, 'zeroLiquidityActual');
@@ -205,7 +205,7 @@ describe('AlgebraPool', () => {
             ).to.be.revertedWithCustomError(pool, 'zeroLiquidityActual');
           });
 
-          it('fails if token1 payed 0', async () => {
+          it('fails if token1 paid 0', async () => {
             await expect(
               payer.mint(pool, wallet.address, minTick + tickSpacing, maxTick - tickSpacing, 100, 100, 0)
             ).to.be.revertedWithCustomError(pool, 'zeroLiquidityActual');
@@ -222,7 +222,7 @@ describe('AlgebraPool', () => {
             ).to.be.revertedWithCustomError(pool, 'zeroLiquidityActual');
           });
 
-          it('fails if token0 hardly underpayed', async () => {
+          it('fails if token0 hardly underpaid', async () => {
             await expect(
               payer.mint(
                 pool,
@@ -236,7 +236,7 @@ describe('AlgebraPool', () => {
             ).to.be.revertedWithCustomError(pool, 'zeroLiquidityActual');
           });
 
-          it('fails if token1 hardly underpayed', async () => {
+          it('fails if token1 hardly underpaid', async () => {
             await swapToHigherPrice(encodePriceSqrt(10, 1), wallet.address);
             await expect(
               payer.mint(

--- a/src/core/test/AlgebraPool.spec.ts
+++ b/src/core/test/AlgebraPool.spec.ts
@@ -21,6 +21,8 @@ import {
   MAX_SQRT_RATIO,
   MIN_SQRT_RATIO,
   SwapToPriceFunction,
+  MAX_TICK,
+  MIN_TICK,
 } from './shared/utilities';
 
 import {
@@ -1170,10 +1172,48 @@ describe('AlgebraPool', () => {
       describe('after initialization', () => {
         beforeEach('initialize the pool at price of 10:1', async () => {
           await pool.initialize(encodePriceSqrt(1, 10));
-          await mint(wallet.address, minTick, maxTick, 3161);
         });
 
+        describe('swaps without liquidity', async() => {
+          it('can swap to max tick', async() => {
+            await swapExact1For0(1, wallet.address);
+            const tick = (await pool.globalState()).tick;
+            expect(tick).to.be.eq(MAX_TICK - 1);
+          })
+
+          it('can swap to min tick', async() => {
+            await swapExact0For1(1, wallet.address);
+            const tick = (await pool.globalState()).tick;
+            expect(tick).to.be.eq(MIN_TICK);
+          })
+
+          it('can swap through whole price range', async() => {
+            await swapExact0For1(1, wallet.address);
+            let tick = (await pool.globalState()).tick;
+            expect(tick).to.be.eq(MIN_TICK);
+            await swapExact1For0(1, wallet.address);
+            tick = (await pool.globalState()).tick;
+            expect(tick).to.be.eq(MAX_TICK - 1);
+            await swapExact0For1(1, wallet.address);
+            tick = (await pool.globalState()).tick;
+            expect(tick).to.be.eq(MIN_TICK);
+          })
+
+          it('can swap to lower price', async() => {
+            await swapExact0For1(1, wallet.address, encodePriceSqrt(1, 1000));
+            const price = (await pool.globalState()).price;
+            expect(price).to.be.eq(encodePriceSqrt(1, 1000));
+          })
+
+          it('can swap to higher price', async() => {
+            await swapExact1For0(1, wallet.address, encodePriceSqrt(1000, 1));
+            const price = (await pool.globalState()).price;
+            expect(price).to.be.eq(encodePriceSqrt(1000, 1));
+          })
+        })
+
         it('fails if required int256.min', async () => {
+          await mint(wallet.address, minTick, maxTick, 3161);
           await expect(
             pool.swap(
               other.address,

--- a/src/core/test/AlgebraPool.spec.ts
+++ b/src/core/test/AlgebraPool.spec.ts
@@ -1229,7 +1229,7 @@ describe('AlgebraPool', () => {
 
     describe('#swapWithPaymentInAdvance', async () => {
       it('fails if not initialized', async () => {
-        expect(swapExact0For1SupportingFee(100, other.address)).to.be.revertedWithCustomError(pool, 'notInitialized');
+        await expect(swapExact0For1SupportingFee(100, other.address)).to.be.revertedWithCustomError(pool, 'notInitialized');
       });
       describe('after initialization', () => {
         beforeEach('initialize the pool at price of 10:1', async () => {

--- a/src/core/test/AlgebraPool.swaps.spec.ts
+++ b/src/core/test/AlgebraPool.swaps.spec.ts
@@ -81,7 +81,7 @@ function swapCaseToDescription(testCase: SwapTestCase): string {
     } else {
       let title = '';
       if (testCase.comissionOnTransaction) {
-        title = 'Token with comission ';
+        title = 'Token with commission ';
       }
       if (testCase.zeroToOne) {
         return `${title}swap exactly ${formatTokenAmount(testCase.amount0)} token0 for token1${priceClause}`;

--- a/src/core/test/__snapshots__/AlgebraFactory.spec.ts.snap
+++ b/src/core/test/__snapshots__/AlgebraFactory.spec.ts.snap
@@ -4,6 +4,6 @@ exports[`AlgebraFactory #createPool gas [ @skip-on-coverage ] 1`] = `4217915`;
 
 exports[`AlgebraFactory #createPool gas for second pool [ @skip-on-coverage ] 1`] = `4217915`;
 
-exports[`AlgebraFactory factory bytecode size  [ @skip-on-coverage ] 1`] = `7745`;
+exports[`AlgebraFactory factory bytecode size  [ @skip-on-coverage ] 1`] = `7811`;
 
 exports[`AlgebraFactory pool bytecode size  [ @skip-on-coverage ] 1`] = `19990`;

--- a/src/core/test/__snapshots__/AlgebraFactory.spec.ts.snap
+++ b/src/core/test/__snapshots__/AlgebraFactory.spec.ts.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AlgebraFactory #createPool gas [ @skip-on-coverage ] 1`] = `4217915`;
+exports[`AlgebraFactory #createPool gas [ @skip-on-coverage ] 1`] = `4232382`;
 
-exports[`AlgebraFactory #createPool gas for second pool [ @skip-on-coverage ] 1`] = `4217915`;
+exports[`AlgebraFactory #createPool gas for second pool [ @skip-on-coverage ] 1`] = `4232382`;
 
 exports[`AlgebraFactory factory bytecode size  [ @skip-on-coverage ] 1`] = `7811`;
 
-exports[`AlgebraFactory pool bytecode size  [ @skip-on-coverage ] 1`] = `19990`;
+exports[`AlgebraFactory pool bytecode size  [ @skip-on-coverage ] 1`] = `20062`;

--- a/src/core/test/__snapshots__/AlgebraPool.gas.spec.ts.snap
+++ b/src/core/test/__snapshots__/AlgebraPool.gas.spec.ts.snap
@@ -32,65 +32,65 @@ exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #collect close t
 
 exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #collect close to worst case, two tokens 1`] = `70347`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint above current price add to position after some time passes 1`] = `126343`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint above current price add to position after some time passes 1`] = `126385`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint above current price add to position existing 1`] = `126343`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint above current price add to position existing 1`] = `126385`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint above current price new position mint first in range 1`] = `280233`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint above current price new position mint first in range 1`] = `280275`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint above current price second position in same range 1`] = `143443`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint above current price second position in same range 1`] = `143485`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint around current price add to position after some time passes 1`] = `151501`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint around current price add to position after some time passes 1`] = `151543`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint around current price add to position existing 1`] = `151501`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint around current price add to position existing 1`] = `151543`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint around current price new position mint first in range 1`] = `358424`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint around current price new position mint first in range 1`] = `358466`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint around current price second position in same range 1`] = `168601`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint around current price second position in same range 1`] = `168643`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint below current price add to position after some time passes 1`] = `126942`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint below current price add to position after some time passes 1`] = `126984`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint below current price add to position existing 1`] = `126942`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint below current price add to position existing 1`] = `126984`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint below current price new position mint first in range 1`] = `354597`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint below current price new position mint first in range 1`] = `354639`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint below current price second position in same range 1`] = `144042`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint below current price second position in same range 1`] = `144084`;
 
 exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #poke best case 1`] = `61556`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `102804`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `102827`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block with no tick movement 1`] = `102773`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block with no tick movement 1`] = `102796`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `118617`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `118640`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `152308`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `152331`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `102942`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `102965`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 large swap crossing several initialized ticks after some time passes 1`] = `152308`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 large swap crossing several initialized ticks after some time passes 1`] = `152331`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `171508`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `171531`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `102804`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `102827`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 second swap in block with no tick movement 1`] = `102768`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 second swap in block with no tick movement 1`] = `102791`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `119441`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `119464`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `153159`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `153182`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 several large swaps with pauses 1`] = `171508`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 several large swaps with pauses 1`] = `171531`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 small swap after several large swaps with pauses 1`] = `102642`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 small swap after several large swaps with pauses 1`] = `102665`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 small swap with filled dataStorage 1`] = `102638`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 small swap with filled dataStorage 1`] = `102661`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact1For0 first swap in block moves tick, no initialized crossings 1`] = `102895`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact1For0 first swap in block moves tick, no initialized crossings 1`] = `102918`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact1For0 first swap in block with no tick movement 1`] = `102843`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact1For0 first swap in block with no tick movement 1`] = `102866`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact1For0 second swap in block with no tick movement 1`] = `102859`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact1For0 second swap in block with no tick movement 1`] = `102882`;
 
 exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #burn above current price burn entire position after some time passes 1`] = `115392`;
 
@@ -120,62 +120,62 @@ exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #collect close to
 
 exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #collect close to worst case, two tokens 1`] = `70347`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint above current price add to position after some time passes 1`] = `126343`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint above current price add to position after some time passes 1`] = `126385`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint above current price add to position existing 1`] = `126343`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint above current price add to position existing 1`] = `126385`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint above current price new position mint first in range 1`] = `280233`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint above current price new position mint first in range 1`] = `280275`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint above current price second position in same range 1`] = `143443`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint above current price second position in same range 1`] = `143485`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint around current price add to position after some time passes 1`] = `151501`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint around current price add to position after some time passes 1`] = `151543`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint around current price add to position existing 1`] = `151501`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint around current price add to position existing 1`] = `151543`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint around current price new position mint first in range 1`] = `358424`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint around current price new position mint first in range 1`] = `358466`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint around current price second position in same range 1`] = `168601`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint around current price second position in same range 1`] = `168643`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint below current price add to position after some time passes 1`] = `126942`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint below current price add to position after some time passes 1`] = `126984`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint below current price add to position existing 1`] = `126942`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint below current price add to position existing 1`] = `126984`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint below current price new position mint first in range 1`] = `354597`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint below current price new position mint first in range 1`] = `354639`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint below current price second position in same range 1`] = `144042`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint below current price second position in same range 1`] = `144084`;
 
 exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #poke best case 1`] = `61556`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `110702`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `110725`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block with no tick movement 1`] = `103010`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block with no tick movement 1`] = `103033`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `126752`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `126775`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `161154`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `161177`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `110840`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `110863`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 large swap crossing several initialized ticks after some time passes 1`] = `161154`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 large swap crossing several initialized ticks after some time passes 1`] = `161177`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `180354`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `180377`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `110702`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `110725`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 second swap in block with no tick movement 1`] = `103005`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 second swap in block with no tick movement 1`] = `103028`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `127576`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `127599`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `162005`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `162028`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 several large swaps with pauses 1`] = `180354`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 several large swaps with pauses 1`] = `180377`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 small swap after several large swaps with pauses 1`] = `102879`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 small swap after several large swaps with pauses 1`] = `102902`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 small swap with filled dataStorage 1`] = `102875`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 small swap with filled dataStorage 1`] = `102898`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact1For0 first swap in block moves tick, no initialized crossings 1`] = `110793`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact1For0 first swap in block moves tick, no initialized crossings 1`] = `110816`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact1For0 first swap in block with no tick movement 1`] = `103080`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact1For0 first swap in block with no tick movement 1`] = `103103`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact1For0 second swap in block with no tick movement 1`] = `103096`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact1For0 second swap in block with no tick movement 1`] = `103119`;

--- a/src/core/test/__snapshots__/AlgebraPool.gas.spec.ts.snap
+++ b/src/core/test/__snapshots__/AlgebraPool.gas.spec.ts.snap
@@ -32,65 +32,65 @@ exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #collect close t
 
 exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #collect close to worst case, two tokens 1`] = `70347`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint above current price add to position after some time passes 1`] = `126331`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint above current price add to position after some time passes 1`] = `126343`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint above current price add to position existing 1`] = `126331`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint above current price add to position existing 1`] = `126343`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint above current price new position mint first in range 1`] = `280221`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint above current price new position mint first in range 1`] = `280233`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint above current price second position in same range 1`] = `143431`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint above current price second position in same range 1`] = `143443`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint around current price add to position after some time passes 1`] = `151489`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint around current price add to position after some time passes 1`] = `151501`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint around current price add to position existing 1`] = `151489`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint around current price add to position existing 1`] = `151501`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint around current price new position mint first in range 1`] = `358412`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint around current price new position mint first in range 1`] = `358424`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint around current price second position in same range 1`] = `168589`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint around current price second position in same range 1`] = `168601`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint below current price add to position after some time passes 1`] = `126930`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint below current price add to position after some time passes 1`] = `126942`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint below current price add to position existing 1`] = `126930`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint below current price add to position existing 1`] = `126942`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint below current price new position mint first in range 1`] = `354585`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint below current price new position mint first in range 1`] = `354597`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint below current price second position in same range 1`] = `144030`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #mint below current price second position in same range 1`] = `144042`;
 
 exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #poke best case 1`] = `61556`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `102792`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `102804`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block with no tick movement 1`] = `102761`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block with no tick movement 1`] = `102773`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `118605`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `118617`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `152296`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `152308`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `102930`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `102942`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 large swap crossing several initialized ticks after some time passes 1`] = `152296`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 large swap crossing several initialized ticks after some time passes 1`] = `152308`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `171496`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `171508`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `102792`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `102804`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 second swap in block with no tick movement 1`] = `102756`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 second swap in block with no tick movement 1`] = `102768`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `119429`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `119441`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `153147`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `153159`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 several large swaps with pauses 1`] = `171496`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 several large swaps with pauses 1`] = `171508`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 small swap after several large swaps with pauses 1`] = `102630`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 small swap after several large swaps with pauses 1`] = `102642`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 small swap with filled dataStorage 1`] = `102626`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact0For1 small swap with filled dataStorage 1`] = `102638`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact1For0 first swap in block moves tick, no initialized crossings 1`] = `102883`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact1For0 first swap in block moves tick, no initialized crossings 1`] = `102895`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact1For0 first swap in block with no tick movement 1`] = `102831`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact1For0 first swap in block with no tick movement 1`] = `102843`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact1For0 second swap in block with no tick movement 1`] = `102847`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is off #swapExact1For0 second swap in block with no tick movement 1`] = `102859`;
 
 exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #burn above current price burn entire position after some time passes 1`] = `115392`;
 
@@ -120,62 +120,62 @@ exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #collect close to
 
 exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #collect close to worst case, two tokens 1`] = `70347`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint above current price add to position after some time passes 1`] = `126331`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint above current price add to position after some time passes 1`] = `126343`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint above current price add to position existing 1`] = `126331`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint above current price add to position existing 1`] = `126343`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint above current price new position mint first in range 1`] = `280221`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint above current price new position mint first in range 1`] = `280233`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint above current price second position in same range 1`] = `143431`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint above current price second position in same range 1`] = `143443`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint around current price add to position after some time passes 1`] = `151489`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint around current price add to position after some time passes 1`] = `151501`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint around current price add to position existing 1`] = `151489`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint around current price add to position existing 1`] = `151501`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint around current price new position mint first in range 1`] = `358412`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint around current price new position mint first in range 1`] = `358424`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint around current price second position in same range 1`] = `168589`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint around current price second position in same range 1`] = `168601`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint below current price add to position after some time passes 1`] = `126930`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint below current price add to position after some time passes 1`] = `126942`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint below current price add to position existing 1`] = `126930`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint below current price add to position existing 1`] = `126942`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint below current price new position mint first in range 1`] = `354585`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint below current price new position mint first in range 1`] = `354597`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint below current price second position in same range 1`] = `144030`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #mint below current price second position in same range 1`] = `144042`;
 
 exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #poke best case 1`] = `61556`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `110690`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block moves tick, no initialized crossings 1`] = `110702`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block with no tick movement 1`] = `102998`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block with no tick movement 1`] = `103010`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `126740`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block, large swap crossing a single initialized tick 1`] = `126752`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `161142`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block, large swap crossing several initialized ticks 1`] = `161154`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `110828`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 first swap in block, large swap, no initialized crossings 1`] = `110840`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 large swap crossing several initialized ticks after some time passes 1`] = `161142`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 large swap crossing several initialized ticks after some time passes 1`] = `161154`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `180342`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 large swap crossing several initialized ticks second time after some time passes 1`] = `180354`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `110690`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 second swap in block moves tick, no initialized crossings 1`] = `110702`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 second swap in block with no tick movement 1`] = `102993`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 second swap in block with no tick movement 1`] = `103005`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `127564`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 second swap in block, large swap crossing a single initialized tick 1`] = `127576`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `161993`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 second swap in block, large swap crossing several initialized ticks 1`] = `162005`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 several large swaps with pauses 1`] = `180342`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 several large swaps with pauses 1`] = `180354`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 small swap after several large swaps with pauses 1`] = `102867`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 small swap after several large swaps with pauses 1`] = `102879`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 small swap with filled dataStorage 1`] = `102863`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact0For1 small swap with filled dataStorage 1`] = `102875`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact1For0 first swap in block moves tick, no initialized crossings 1`] = `110781`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact1For0 first swap in block moves tick, no initialized crossings 1`] = `110793`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact1For0 first swap in block with no tick movement 1`] = `103068`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact1For0 first swap in block with no tick movement 1`] = `103080`;
 
-exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact1For0 second swap in block with no tick movement 1`] = `103084`;
+exports[`AlgebraPool gas tests [ @skip-on-coverage ] fee is on #swapExact1For0 second swap in block with no tick movement 1`] = `103096`;

--- a/src/core/test/__snapshots__/AlgebraPool.swaps.spec.ts.snap
+++ b/src/core/test/__snapshots__/AlgebraPool.swaps.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AlgebraPool swap tests 1:1 price, 0 liquidity, all liquidity around current price Token with comission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests 1:1 price, 0 liquidity, all liquidity around current price Token with commission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "1994009290088178439",
   "amount0Delta": "1",
@@ -16,7 +16,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:1 price, 0 liquidity, all liquidity around current price Token with comission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests 1:1 price, 0 liquidity, all liquidity around current price Token with commission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "1994009290088178439",
   "amount0Delta": "950",
@@ -32,7 +32,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:1 price, 0 liquidity, all liquidity around current price Token with comission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests 1:1 price, 0 liquidity, all liquidity around current price Token with commission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
 Object {
   "amount0Before": "1994009290088178439",
   "amount0Delta": "-941",
@@ -48,7 +48,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:1 price, 0 liquidity, all liquidity around current price Token with comission swap exactly 1.0000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests 1:1 price, 0 liquidity, all liquidity around current price Token with commission swap exactly 1.0000 token0 for token1 1`] = `
 Object {
   "amount0Before": "1994009290088178439",
   "amount0Delta": "950000000000000000",
@@ -64,7 +64,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:1 price, 0 liquidity, all liquidity around current price Token with comission swap exactly 1.0000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests 1:1 price, 0 liquidity, all liquidity around current price Token with commission swap exactly 1.0000 token1 for token0 1`] = `
 Object {
   "amount0Before": "1994009290088178439",
   "amount0Delta": "-639527396177709202",
@@ -412,7 +412,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:1 price, 2e18 max range liquidity Token with comission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests 1:1 price, 2e18 max range liquidity Token with commission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "2000000000000000000",
   "amount0Delta": "1",
@@ -428,7 +428,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:1 price, 2e18 max range liquidity Token with comission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests 1:1 price, 2e18 max range liquidity Token with commission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "2000000000000000000",
   "amount0Delta": "950",
@@ -444,7 +444,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:1 price, 2e18 max range liquidity Token with comission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests 1:1 price, 2e18 max range liquidity Token with commission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
 Object {
   "amount0Before": "2000000000000000000",
   "amount0Delta": "-946",
@@ -460,7 +460,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:1 price, 2e18 max range liquidity Token with comission swap exactly 1.0000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests 1:1 price, 2e18 max range liquidity Token with commission swap exactly 1.0000 token0 for token1 1`] = `
 Object {
   "amount0Before": "2000000000000000000",
   "amount0Delta": "950000000000000000",
@@ -476,7 +476,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:1 price, 2e18 max range liquidity Token with comission swap exactly 1.0000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests 1:1 price, 2e18 max range liquidity Token with commission swap exactly 1.0000 token1 for token0 1`] = `
 Object {
   "amount0Before": "2000000000000000000",
   "amount0Delta": "-642756561423748367",
@@ -824,7 +824,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:1 price, additional liquidity around current price Token with comission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests 1:1 price, additional liquidity around current price Token with commission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "3994009290088178439",
   "amount0Delta": "1",
@@ -840,7 +840,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:1 price, additional liquidity around current price Token with comission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests 1:1 price, additional liquidity around current price Token with commission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "3994009290088178439",
   "amount0Delta": "950",
@@ -856,7 +856,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:1 price, additional liquidity around current price Token with comission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests 1:1 price, additional liquidity around current price Token with commission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
 Object {
   "amount0Before": "3994009290088178439",
   "amount0Delta": "-946",
@@ -872,7 +872,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:1 price, additional liquidity around current price Token with comission swap exactly 1.0000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests 1:1 price, additional liquidity around current price Token with commission swap exactly 1.0000 token0 for token1 1`] = `
 Object {
   "amount0Before": "3994009290088178439",
   "amount0Delta": "950000000000000000",
@@ -888,7 +888,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:1 price, additional liquidity around current price Token with comission swap exactly 1.0000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests 1:1 price, additional liquidity around current price Token with commission swap exactly 1.0000 token1 for token0 1`] = `
 Object {
   "amount0Before": "3994009290088178439",
   "amount0Delta": "-763747361724655808",
@@ -1236,7 +1236,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:10 price, 2e18 max range liquidity Token with comission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests 1:10 price, 2e18 max range liquidity Token with commission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "6324555320336758664",
   "amount0Delta": "1",
@@ -1252,7 +1252,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:10 price, 2e18 max range liquidity Token with comission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests 1:10 price, 2e18 max range liquidity Token with commission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "6324555320336758664",
   "amount0Delta": "950",
@@ -1268,7 +1268,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:10 price, 2e18 max range liquidity Token with comission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests 1:10 price, 2e18 max range liquidity Token with commission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
 Object {
   "amount0Before": "6324555320336758664",
   "amount0Delta": "-9469",
@@ -1284,7 +1284,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:10 price, 2e18 max range liquidity Token with comission swap exactly 1.0000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests 1:10 price, 2e18 max range liquidity Token with commission swap exactly 1.0000 token0 for token1 1`] = `
 Object {
   "amount0Before": "6324555320336758664",
   "amount0Delta": "950000000000000000",
@@ -1300,7 +1300,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 1:10 price, 2e18 max range liquidity Token with comission swap exactly 1.0000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests 1:10 price, 2e18 max range liquidity Token with commission swap exactly 1.0000 token1 for token0 1`] = `
 Object {
   "amount0Before": "6324555320336758664",
   "amount0Delta": "-3792277533964253511",
@@ -1636,7 +1636,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 10:1 price, 2e18 max range liquidity Token with comission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests 10:1 price, 2e18 max range liquidity Token with commission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "632455532033675867",
   "amount0Delta": "1",
@@ -1652,7 +1652,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 10:1 price, 2e18 max range liquidity Token with comission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests 10:1 price, 2e18 max range liquidity Token with commission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "632455532033675867",
   "amount0Delta": "950",
@@ -1668,7 +1668,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 10:1 price, 2e18 max range liquidity Token with comission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests 10:1 price, 2e18 max range liquidity Token with commission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
 Object {
   "amount0Before": "632455532033675867",
   "amount0Delta": "-94",
@@ -1684,7 +1684,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 10:1 price, 2e18 max range liquidity Token with comission swap exactly 1.0000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests 10:1 price, 2e18 max range liquidity Token with commission swap exactly 1.0000 token0 for token1 1`] = `
 Object {
   "amount0Before": "632455532033675867",
   "amount0Delta": "950000000000000000",
@@ -1700,7 +1700,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests 10:1 price, 2e18 max range liquidity Token with comission swap exactly 1.0000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests 10:1 price, 2e18 max range liquidity Token with commission swap exactly 1.0000 token1 for token0 1`] = `
 Object {
   "amount0Before": "632455532033675867",
   "amount0Delta": "-82378236022627290",
@@ -2036,7 +2036,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests close to max price Token with comission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests close to max price Token with commission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "1",
   "amount0Delta": "1",
@@ -2052,7 +2052,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests close to max price Token with comission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests close to max price Token with commission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "1",
   "amount0Delta": "950",
@@ -2068,7 +2068,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests close to max price Token with comission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests close to max price Token with commission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
 Object {
   "amount0Before": "1",
   "amount0Delta": "0",
@@ -2084,7 +2084,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests close to max price Token with comission swap exactly 1.0000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests close to max price Token with commission swap exactly 1.0000 token0 for token1 1`] = `
 Object {
   "amount0Before": "1",
   "amount0Delta": "950000000000000000",
@@ -2100,7 +2100,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests close to max price Token with comission swap exactly 1.0000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests close to max price Token with commission swap exactly 1.0000 token1 for token0 1`] = `
 Object {
   "amount0Before": "1",
   "amount0Delta": "0",
@@ -2436,7 +2436,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests close to min price Token with comission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests close to min price Token with commission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "26037782196502120275425782622539039026",
   "amount0Delta": "1",
@@ -2452,7 +2452,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests close to min price Token with comission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests close to min price Token with commission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "26037782196502120275425782622539039026",
   "amount0Delta": "950",
@@ -2468,7 +2468,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests close to min price Token with comission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests close to min price Token with commission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
 Object {
   "amount0Before": "26037782196502120275425782622539039026",
   "amount0Delta": "-26033559016752578023844169530417070688",
@@ -2484,7 +2484,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests close to min price Token with comission swap exactly 1.0000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests close to min price Token with commission swap exactly 1.0000 token0 for token1 1`] = `
 Object {
   "amount0Before": "26037782196502120275425782622539039026",
   "amount0Delta": "950000000000000000",
@@ -2500,7 +2500,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests close to min price Token with comission swap exactly 1.0000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests close to min price Token with commission swap exactly 1.0000 token1 for token0 1`] = `
 Object {
   "amount0Before": "26037782196502120275425782622539039026",
   "amount0Delta": "-26037782196502120271202586719039065421",
@@ -2836,7 +2836,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests initialized at the max ratio Token with comission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests initialized at the max ratio Token with commission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "0",
   "amount0Delta": "1",
@@ -2852,7 +2852,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests initialized at the max ratio Token with comission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests initialized at the max ratio Token with commission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "0",
   "amount0Delta": "950",
@@ -2868,7 +2868,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests initialized at the max ratio Token with comission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests initialized at the max ratio Token with commission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
 Object {
   "poolBalance0": "0",
   "poolBalance1": "36796311329002736532545403775337522448",
@@ -2878,7 +2878,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests initialized at the max ratio Token with comission swap exactly 1.0000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests initialized at the max ratio Token with commission swap exactly 1.0000 token0 for token1 1`] = `
 Object {
   "amount0Before": "0",
   "amount0Delta": "950000000000000000",
@@ -2894,7 +2894,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests initialized at the max ratio Token with comission swap exactly 1.0000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests initialized at the max ratio Token with commission swap exactly 1.0000 token1 for token0 1`] = `
 Object {
   "poolBalance0": "0",
   "poolBalance1": "36796311329002736532545403775337522448",
@@ -3188,7 +3188,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests initialized at the min ratio Token with comission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests initialized at the min ratio Token with commission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
 Object {
   "poolBalance0": "36796311322104302062438284732106019258",
   "poolBalance1": "0",
@@ -3198,7 +3198,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests initialized at the min ratio Token with comission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests initialized at the min ratio Token with commission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
 Object {
   "poolBalance0": "36796311322104302062438284732106019258",
   "poolBalance1": "0",
@@ -3208,7 +3208,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests initialized at the min ratio Token with comission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests initialized at the min ratio Token with commission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
 Object {
   "amount0Before": "36796311322104302062438284732106019258",
   "amount0Delta": "-36792087942071636995454038869392384020",
@@ -3224,7 +3224,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests initialized at the min ratio Token with comission swap exactly 1.0000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests initialized at the min ratio Token with commission swap exactly 1.0000 token0 for token1 1`] = `
 Object {
   "poolBalance0": "36796311322104302062438284732106019258",
   "poolBalance1": "0",
@@ -3234,7 +3234,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests initialized at the min ratio Token with comission swap exactly 1.0000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests initialized at the min ratio Token with commission swap exactly 1.0000 token1 for token0 1`] = `
 Object {
   "amount0Before": "36796311322104302062438284732106019258",
   "amount0Delta": "-36796311322104302058215088828606045652",
@@ -3540,7 +3540,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests large liquidity around current price (stable swap) Token with comission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests large liquidity around current price (stable swap) Token with commission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "999700069986003",
   "amount0Delta": "1",
@@ -3556,7 +3556,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests large liquidity around current price (stable swap) Token with comission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests large liquidity around current price (stable swap) Token with commission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "999700069986003",
   "amount0Delta": "950",
@@ -3572,7 +3572,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests large liquidity around current price (stable swap) Token with comission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests large liquidity around current price (stable swap) Token with commission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
 Object {
   "amount0Before": "999700069986003",
   "amount0Delta": "-948",
@@ -3588,7 +3588,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests large liquidity around current price (stable swap) Token with comission swap exactly 1.0000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests large liquidity around current price (stable swap) Token with commission swap exactly 1.0000 token0 for token1 1`] = `
 Object {
   "amount0Before": "999700069986003",
   "amount0Delta": "1000700370186095",
@@ -3604,7 +3604,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests large liquidity around current price (stable swap) Token with comission swap exactly 1.0000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests large liquidity around current price (stable swap) Token with commission swap exactly 1.0000 token1 for token0 1`] = `
 Object {
   "amount0Before": "999700069986003",
   "amount0Delta": "-999700069986002",
@@ -3952,7 +3952,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests max full range liquidity at 1:1 price with default fee Token with comission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests max full range liquidity at 1:1 price with default fee Token with commission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "40564824043007195765027393300202",
   "amount0Delta": "1",
@@ -3968,7 +3968,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests max full range liquidity at 1:1 price with default fee Token with comission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests max full range liquidity at 1:1 price with default fee Token with commission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "40564824043007195765027393300202",
   "amount0Delta": "950",
@@ -3984,7 +3984,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests max full range liquidity at 1:1 price with default fee Token with comission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests max full range liquidity at 1:1 price with default fee Token with commission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
 Object {
   "amount0Before": "40564824043007195765027393300202",
   "amount0Delta": "-512",
@@ -4000,7 +4000,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests max full range liquidity at 1:1 price with default fee Token with comission swap exactly 1.0000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests max full range liquidity at 1:1 price with default fee Token with commission swap exactly 1.0000 token0 for token1 1`] = `
 Object {
   "amount0Before": "40564824043007195765027393300202",
   "amount0Delta": "950000000000000000",
@@ -4016,7 +4016,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests max full range liquidity at 1:1 price with default fee Token with comission swap exactly 1.0000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests max full range liquidity at 1:1 price with default fee Token with commission swap exactly 1.0000 token1 for token0 1`] = `
 Object {
   "amount0Before": "40564824043007195765027393300202",
   "amount0Delta": "-947149999999977442",
@@ -4352,7 +4352,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests token0 liquidity only Token with comission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests token0 liquidity only Token with commission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "1995041008271423675",
   "amount0Delta": "0",
@@ -4368,7 +4368,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests token0 liquidity only Token with comission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests token0 liquidity only Token with commission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "1995041008271423675",
   "amount0Delta": "0",
@@ -4384,7 +4384,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests token0 liquidity only Token with comission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests token0 liquidity only Token with commission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
 Object {
   "amount0Before": "1995041008271423675",
   "amount0Delta": "-946",
@@ -4400,7 +4400,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests token0 liquidity only Token with comission swap exactly 1.0000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests token0 liquidity only Token with commission swap exactly 1.0000 token0 for token1 1`] = `
 Object {
   "amount0Before": "1995041008271423675",
   "amount0Delta": "0",
@@ -4416,7 +4416,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests token0 liquidity only Token with comission swap exactly 1.0000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests token0 liquidity only Token with commission swap exactly 1.0000 token1 for token0 1`] = `
 Object {
   "amount0Before": "1995041008271423675",
   "amount0Delta": "-642756561423748367",
@@ -4764,7 +4764,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests token1 liquidity only Token with comission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests token1 liquidity only Token with commission swap exactly 0.0000000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "0",
   "amount0Delta": "1",
@@ -4780,7 +4780,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests token1 liquidity only Token with comission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests token1 liquidity only Token with commission swap exactly 0.0000000000000010000 token0 for token1 1`] = `
 Object {
   "amount0Before": "0",
   "amount0Delta": "950",
@@ -4796,7 +4796,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests token1 liquidity only Token with comission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests token1 liquidity only Token with commission swap exactly 0.0000000000000010000 token1 for token0 1`] = `
 Object {
   "amount0Before": "0",
   "amount0Delta": "0",
@@ -4812,7 +4812,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests token1 liquidity only Token with comission swap exactly 1.0000 token0 for token1 1`] = `
+exports[`AlgebraPool swap tests token1 liquidity only Token with commission swap exactly 1.0000 token0 for token1 1`] = `
 Object {
   "amount0Before": "0",
   "amount0Delta": "950000000000000000",
@@ -4828,7 +4828,7 @@ Object {
 }
 `;
 
-exports[`AlgebraPool swap tests token1 liquidity only Token with comission swap exactly 1.0000 token1 for token0 1`] = `
+exports[`AlgebraPool swap tests token1 liquidity only Token with commission swap exactly 1.0000 token1 for token0 1`] = `
 Object {
   "amount0Before": "0",
   "amount0Delta": "0",

--- a/src/farming/test/unit/EternalFarms.spec.ts
+++ b/src/farming/test/unit/EternalFarms.spec.ts
@@ -701,7 +701,7 @@ describe('unit/EternalFarms', () => {
     })
   })
 
-  xdescribe('swap gas [ @skip-on-coverage ]', async () => {
+  describe.skip('swap gas [ @skip-on-coverage ]', async () => {
     it('3 swaps', async () => {
       timestamps = makeTimestamps((await blockTimestamp()) + 1_000)
 

--- a/src/periphery/contracts/libraries/NFTDescriptor.sol
+++ b/src/periphery/contracts/libraries/NFTDescriptor.sol
@@ -173,7 +173,7 @@ library NFTDescriptor {
         uint256 sigfigs;
         // length of decimal string
         uint8 bufferLength;
-        // ending index for significant figures (funtion works backwards when copying sigfigs)
+        // ending index for significant figures (function works backwards when copying sigfigs)
         uint8 sigfigIndex;
         // index of decimal place (0 if no decimal)
         uint8 decimalIndex;
@@ -238,7 +238,7 @@ library NFTDescriptor {
     function sigfigsRounded(uint256 value, uint8 digits) private pure returns (uint256, bool) {
         bool extraDigit;
         if (digits > 5) {
-            value = value / ((10**(digits - 5)));
+            value = value / ((10 ** (digits - 5)));
         }
         bool roundUp = value % 10 > 4;
         value = value / 10;
@@ -261,12 +261,12 @@ library NFTDescriptor {
         uint256 difference = abs(int256(uint256(baseTokenDecimals)) - int256(uint256(quoteTokenDecimals)));
         if (difference > 0 && difference <= 18) {
             if (baseTokenDecimals > quoteTokenDecimals) {
-                adjustedSqrtRatioX96 = sqrtRatioX96 * (10**(difference / 2));
+                adjustedSqrtRatioX96 = sqrtRatioX96 * (10 ** (difference / 2));
                 if (difference % 2 == 1) {
                     adjustedSqrtRatioX96 = FullMath.mulDiv(adjustedSqrtRatioX96, sqrt10X128, 1 << 128);
                 }
             } else {
-                adjustedSqrtRatioX96 = sqrtRatioX96 / (10**(difference / 2));
+                adjustedSqrtRatioX96 = sqrtRatioX96 / (10 ** (difference / 2));
                 if (difference % 2 == 1) {
                     adjustedSqrtRatioX96 = FullMath.mulDiv(adjustedSqrtRatioX96, 1 << 128, sqrt10X128);
                 }
@@ -290,13 +290,13 @@ library NFTDescriptor {
         uint256 adjustedSqrtRatioX96 = adjustForDecimalPrecision(sqrtRatioX96, baseTokenDecimals, quoteTokenDecimals);
         uint256 value = FullMath.mulDiv(adjustedSqrtRatioX96, adjustedSqrtRatioX96, 1 << 64);
 
-        bool priceBelow1 = adjustedSqrtRatioX96 < 2**96;
+        bool priceBelow1 = adjustedSqrtRatioX96 < 2 ** 96;
         if (priceBelow1) {
-            // 10 ** 43 is precision needed to retreive 5 sigfigs of smallest possible price + 1 for rounding
-            value = FullMath.mulDiv(value, 10**44, 1 << 128);
+            // 10 ** 43 is precision needed to retrieve 5 sigfigs of smallest possible price + 1 for rounding
+            value = FullMath.mulDiv(value, 10 ** 44, 1 << 128);
         } else {
             // leave precision for 4 decimal places + 1 place for rounding
-            value = FullMath.mulDiv(value, 10**5, 1 << 128);
+            value = FullMath.mulDiv(value, 10 ** 5, 1 << 128);
         }
 
         // get digit count
@@ -387,7 +387,7 @@ library NFTDescriptor {
             params.sigfigIndex = uint8((params.bufferLength) - 2);
             params.isLessThanOne = true;
         }
-        params.sigfigs = uint256(fee) / (10**(feeDigits.digits - feeDigits.numSigfigs));
+        params.sigfigs = uint256(fee) / (10 ** (feeDigits.digits - feeDigits.numSigfigs));
         params.isPercent = true;
         params.decimalIndex = feeDigits.digits > 4 ? uint8(feeDigits.digits - 4) : 0;
 
@@ -468,11 +468,7 @@ library NFTDescriptor {
         return NFTSVG.generateSVG(defs, body);
     }
 
-    function overRange(
-        int24 tickLower,
-        int24 tickUpper,
-        int24 tickCurrent
-    ) private pure returns (int8) {
+    function overRange(int24 tickLower, int24 tickUpper, int24 tickCurrent) private pure returns (int8) {
         if (tickCurrent < tickLower) {
             return -1;
         } else if (tickCurrent > tickUpper) {
@@ -496,11 +492,7 @@ library NFTDescriptor {
         return string((token >> offset).toHexStringNoPrefix(3));
     }
 
-    function getCircleCoord(
-        uint256 tokenAddress,
-        uint256 offset,
-        uint256 tokenId
-    ) internal pure returns (uint256) {
+    function getCircleCoord(uint256 tokenAddress, uint256 offset, uint256 tokenId) internal pure returns (uint256) {
         return (sliceTokenHex(tokenAddress, offset) * tokenId) % 255;
     }
 

--- a/src/periphery/contracts/libraries/PoolAddress.sol
+++ b/src/periphery/contracts/libraries/PoolAddress.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.5.0;
 /// @dev Credit to Uniswap Labs under GPL-2.0-or-later license:
 /// https://github.com/Uniswap/v3-periphery
 library PoolAddress {
-    bytes32 internal constant POOL_INIT_CODE_HASH = 0x61b0e9f440885c12064d37d2b40505fa24d8ca39f690c9ad18a79806cdceca38;
+    bytes32 internal constant POOL_INIT_CODE_HASH = 0x634db8d334cf38f8d669064fefe5c4f5cf194cab753e4ed23256fb4dd545ed7a;
 
     /// @notice The identifying key of the pool
     struct PoolKey {

--- a/src/periphery/test/NFTDescriptor.spec.ts
+++ b/src/periphery/test/NFTDescriptor.spec.ts
@@ -364,7 +364,7 @@ describe('NFTDescriptor', () => {
     let minTick: number
     let maxTick: number
 
-    xdescribe('when tickspacing is 10', () => {
+    describe.skip('when tickspacing is 10', () => {
       before(() => {
         tickSpacing = TICK_SPACINGS[FeeAmount.LOW]
         minTick = getMinTick(tickSpacing)
@@ -418,7 +418,7 @@ describe('NFTDescriptor', () => {
       })
     })
 
-    xdescribe('when tickspacing is 200', () => {
+    describe.skip('when tickspacing is 200', () => {
       before(() => {
         tickSpacing = TICK_SPACINGS[FeeAmount.HIGH]
         minTick = getMinTick(tickSpacing)

--- a/src/plugins/contracts/libraries/DataStorage.sol
+++ b/src/plugins/contracts/libraries/DataStorage.sol
@@ -387,7 +387,7 @@ library DataStorage {
   /// @notice Calculates cumulative tick at the moment of `time` - `secondsAgo`
   /// @dev More optimal than via `getSingleTimepoint`
   /// @return tickCumulative The cumulative tick
-  /// @return indexBeforeOrAt The index of closest timepoint before ot at the moment of `time` - `secondsAgo`
+  /// @return indexBeforeOrAt The index of closest timepoint before or at the moment of `time` - `secondsAgo`
   function _getTickCumulativeAt(
     Timepoint[UINT16_MODULO] storage self,
     uint32 time,
@@ -427,7 +427,7 @@ library DataStorage {
   /// @return beforeOrAt The timepoint recorded before, or at, the target
   /// @return atOrAfter The timepoint recorded at, or after, the target
   /// @return samePoint Are `beforeOrAt` and `atOrAfter` the same or not
-  /// @return indexBeforeOrAt The index of closest timepoint before ot at the moment of `target`
+  /// @return indexBeforeOrAt The index of closest timepoint before or at the moment of `target`
   function _getTimepointsAt(
     Timepoint[UINT16_MODULO] storage self,
     uint32 currentTime,

--- a/src/plugins/contracts/test/echidna/echidna.config.yml
+++ b/src/plugins/contracts/test/echidna/echidna.config.yml
@@ -46,7 +46,7 @@ cryticArgs: ['--hardhat-ignore-compile']
 # quiet: false
 # #initialize the blockchain with some data
 # initialize: null
-# #whether ot not to use the multi-abi mode of testing
+# #whether or not to use the multi-abi mode of testing
 # multi-abi: false
 # #benchmarkMode enables benchmark mode
 # benchmarkMode: false

--- a/src/plugins/echidna.config.yml
+++ b/src/plugins/echidna.config.yml
@@ -45,7 +45,7 @@ coverage: false
 # quiet: false
 # #initialize the blockchain with some data
 # initialize: null
-# #whether ot not to use the multi-abi mode of testing
+# #whether or not to use the multi-abi mode of testing
 # multi-abi: false
 # #benchmarkMode enables benchmark mode
 # benchmarkMode: false


### PR DESCRIPTION
- I thought it might make sense to make the hash of the pool's bytecode a public variable to make it easier for third parties to access it. This can simplify the integration of the protocol, as well as automatically check for version matching between different deployments
- I renamed the internal methods of the PriceMovementMath library to more meaningful names
- added new tests for Echidna, checking the consistency of internal methods of the PriceMovementMath library