### PR TITLE
Github action to perform stateless formal verification on some part of the codebase using Echidna

### DIFF
--- a/.github/workflows/echidna_core_verification.yaml
+++ b/.github/workflows/echidna_core_verification.yaml
@@ -1,0 +1,46 @@
+name: Echidna Core Verification
+
+on:
+  push:
+    branches:
+      - integral-v1.2.2
+  pull_request:
+    branches:
+      - integral-v1.2.2
+
+jobs:
+  VerificationAsserts:
+    strategy:
+      matrix:
+        testName:
+          - LowGasSafeMathEchidnaTest
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm run ci-install
+
+      - name: Compile contracts
+        run: npm run compile
+        working-directory: ./src/core
+
+      - name: Run ${{ matrix.testName }}
+        uses: crytic/echidna-action@v2
+        with:
+          echidna-version: edge
+          solc-version: 0.8.20
+          files: ./src/core/contracts/test/echidna/${{ matrix.testName }}.sol
+          contract: ${{ matrix.testName }}
+          crytic-args: --hardhat-ignore-compile
+          solc-args: --evm-version paris
+          config: ./src/core/contracts/test/echidna/echidna.verification.config.yml

--- a/src/core/contracts/test/echidna/echidna.verification.config.yml
+++ b/src/core/contracts/test/echidna/echidna.verification.config.yml
@@ -1,0 +1,12 @@
+symExec: true
+symExecTimeout: 600
+symExecMaxExplore: 100
+symExecMaxIters: 100
+
+format: text
+testMode: assertion
+
+maxTimeDelay: 0
+maxBlockDelay: 0
+workers: 0
+seqLen: 1


### PR DESCRIPTION
Following the publication of [the blog post about the new Echidna capabilities using symbolic execution](https://gustavo-grieco.github.io/blog/echidna-symexec/), I'm preparing a PR that runs the verification on some contracts that are known to be analyzed correctly in a short time.

PS: as expected, I will need approval to run this new workflow.